### PR TITLE
fix: correct dead search filter, admin fatal, and permalink loop dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ wp-config.php
 node_modules
 
 /vendor/
+
+# Editor directories
+.vscode/

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -3,6 +3,15 @@
 
 	<description>A custom set of rules to check for a WPized WordPress project</description>
 
+	<!-- Scan the whole plugin by default, so `phpcs` needs no path argument. -->
+	<file>.</file>
+
+	<!--
+	WPCS 3.x dropped its JavaScript and CSS sniffs, so running PHP sniffs over
+	.js/.css files only produces noise. Restrict the scan to PHP.
+	-->
+	<arg name="extensions" value="php"/>
+
 	<!-- Exclude WP Core folders and files from being checked. -->
 	<exclude-pattern>/docroot/wp-admin/*</exclude-pattern>
 	<exclude-pattern>/docroot/wp-includes/*</exclude-pattern>
@@ -87,6 +96,18 @@
 				<element value="ucscgiving"/>
 			</property>
 		</properties>
+	</rule>
+
+	<!--
+	lib/templates/ holds block markup, not PHP source. The files are either pure
+	block comments or markup with a couple of `require` calls, so a file-level
+	docblock is neither expected nor useful there.
+	-->
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>/lib/templates/*</exclude-pattern>
+	</rule>
+	<rule ref="Internal.NoCodeFound">
+		<exclude-pattern>/lib/templates/*</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/lib/functions/general.php
+++ b/lib/functions/general.php
@@ -8,6 +8,8 @@
  * @package ucsc-giving-functionality
  */
 
+defined( 'ABSPATH' ) || exit;
+
 add_action( 'init', 'ucscgiving_register_fund_url_block_binding' );
 
 /**
@@ -54,30 +56,41 @@ function ucscgiving_fund_url() {
 /**
  * Set permalinks to the external Giving URL
  *
- * @return string
+ * Funds with a "Standard" fund type link out to the external giving site
+ * rather than to their own single post. Everything else is left untouched.
+ *
+ * @param string  $post_link The post's permalink.
+ * @param WP_Post $post      The post being linked to.
+ * @return string The external giving URL, or the unmodified permalink.
  */
 function ucscgiving_link_filter( $post_link, $post ) {
-		$baseurl     = get_field( 'base_url', 'option' );
-		$designation = get_post_meta( get_the_ID(), 'designation', true );
-		$fund_id     = get_field( 'fund-type-term' );
-		$fund        = get_term( $fund_id );
-		$fundurl     = '';
-	if ( ( 'fund' === $post->post_type ) ) {
-		if ( ! is_wp_error( $fund ) ) {
-			$fundname = $fund->name;
-			if ( $fundname === 'Standard' ) {
-				if ( ! empty( $baseurl ) && ! empty( $designation ) ) {
-					$fundurl = esc_attr( $baseurl . $designation );
-				} elseif ( ! empty( $baseurl ) ) {
-					$fundurl = esc_attr( $baseurl );
-				} else {
-					$fundurl = '';
-				}
-				return $fundurl;
-			}
-		}
-	}
+	if ( 'fund' !== $post->post_type ) {
 		return $post_link;
+	}
+
+	// Read against $post->ID rather than loop state, so this is correct in
+	// admin list tables, REST responses and feeds as well as the main loop.
+	$fund_id = get_field( 'fund-type-term', $post->ID );
+
+	if ( empty( $fund_id ) ) {
+		return $post_link;
+	}
+
+	$fund = get_term( $fund_id );
+
+	if ( is_wp_error( $fund ) || ! $fund instanceof WP_Term || 'Standard' !== $fund->name ) {
+		return $post_link;
+	}
+
+	$baseurl = get_field( 'base_url', 'option' );
+
+	if ( empty( $baseurl ) ) {
+		return $post_link;
+	}
+
+	$designation = get_post_meta( $post->ID, 'designation', true );
+
+	return esc_url( $baseurl . $designation );
 }
 
 add_filter( 'post_type_link', 'ucscgiving_link_filter', 10, 2 );
@@ -86,7 +99,7 @@ add_filter( 'post_type_link', 'ucscgiving_link_filter', 10, 2 );
  * Register Search block variation for Fund post type
  * description: Registers a custom block variation for the Fund post type
  *
- * @param mixed         $variations
+ * @param array         $variations Registered variations for the block type.
  * @param WP_Block_Type $block_type The block type being filtered.
  * @return mixed
  */
@@ -118,8 +131,8 @@ add_filter( 'get_block_type_variations', 'ucscgiving_create_fund_search_variatio
  * Return Fund search results in Fund archive template
  * description: Returns the Fund search results in its archive template.
  *
- * @param string $template
- * @return string
+ * @param string $template Path to the search template WordPress resolved.
+ * @return string Empty string to fall through to the archive template, or the original path.
  */
 function ucscgiving_fund_search_template( $template ) {
 	if ( is_search() && 'fund' === get_query_var( 'post_type' ) ) {
@@ -129,4 +142,4 @@ function ucscgiving_fund_search_template( $template ) {
 	return $template;
 }
 
-add_action( 'search_template', 'ucscgiving_fund_search_template' );
+add_filter( 'search_template', 'ucscgiving_fund_search_template' );

--- a/lib/functions/settings.php
+++ b/lib/functions/settings.php
@@ -11,11 +11,14 @@
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
 
-/**
- * Register new menu and page in WordPress Settings
- */
+defined( 'ABSPATH' ) || exit;
 
 if ( ! function_exists( 'ucscgiving_add_settings_page' ) ) {
+	/**
+	 * Register new menu and page in WordPress Settings
+	 *
+	 * @return void
+	 */
 	function ucscgiving_add_settings_page() {
 		add_options_page( 'UCSC Giving Functionality plugin page', 'UCSC Giving Functionality', 'manage_options', 'ucsc-giving-functionality-settings', 'ucscgiving_render_plugin_settings_page' );
 	}
@@ -32,6 +35,11 @@ add_action( 'admin_menu', 'ucscgiving_add_settings_page' );
  */
 
 if ( ! function_exists( 'ucscgiving_render_plugin_settings_page' ) ) {
+	/**
+	 * Render the plugin settings/info page.
+	 *
+	 * @return void
+	 */
 	function ucscgiving_render_plugin_settings_page() {
 		$plugin_data        = get_plugin_data( UCSCGIVING_PLUGIN_DIR . '/plugin.php' );
 		$plugin_name        = $plugin_data['Name'];
@@ -59,26 +67,27 @@ if ( ! function_exists( 'ucscgiving_render_plugin_settings_page' ) ) {
 	}
 }
 
+add_filter( 'plugin_action_links_' . UCSCGIVING_PLUGIN_BASE, 'ucscgiving_settings_link' );
+
 /**
  * Add link to plugin settings page from plugin list
+ *
+ * @param array $links Existing plugin action links.
+ * @return array Action links with the settings link appended.
  */
-
-add_filter( 'plugin_action_links_' . UCSCGIVING_PLUGIN_BASE, 'ucscgiving_settings_link' );
 function ucscgiving_settings_link( $links ) {
-	// Build and escape the URL.
-	$url = esc_url(
-		add_query_arg(
-			'page',
-			'ucsc-giving-functionality-settings',
-			get_admin_url() . 'admin.php'
-		)
-	);
-	// Create the link.
-	$settings_link = "<a href='$url'>" . __( 'Settings' ) . '</a>';
-	// Adds the link to the end of the array.
-	array_push(
-		$links,
-		$settings_link
-	);
+	// menu_page_url() resolves the registered parent (options-general.php),
+	// so this stays correct if the page is ever re-parented. It returns an
+	// empty string when the page was never registered — which happens when
+	// add_options_page() bailed on a capability check — so fall back to the
+	// known parent rather than dropping the link entirely.
+	$url = menu_page_url( 'ucsc-giving-functionality-settings', false );
+
+	if ( empty( $url ) ) {
+		$url = admin_url( 'options-general.php?page=ucsc-giving-functionality-settings' );
+	}
+
+	$links[] = '<a href="' . esc_url( $url ) . '">' . esc_html__( 'Settings', 'ucscgiving' ) . '</a>';
+
 	return $links;
 }

--- a/plugin.php
+++ b/plugin.php
@@ -16,6 +16,8 @@
  * @package ucsc-giving-functionality
  */
 
+defined( 'ABSPATH' ) || exit;
+
 // Set plugin directory and base name.
 define( 'UCSCGIVING_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); // Path to plugin directory.
 define( 'UCSCGIVING_PLUGIN_BASE', plugin_basename( __FILE__ ) ); // Plugin base name 'plugin.php' at root.
@@ -38,14 +40,22 @@ if ( ! function_exists( 'ucscgiving_enqueue_admin_styles' ) ) {
 	 * @package ucsc-giving-functionality
 	 */
 	function ucscgiving_enqueue_admin_styles(): void {
-		$settings_css   = plugin_dir_url( __FILE__ ) . 'lib/css/admin-settings.css';
 		$current_screen = get_current_screen();
-		$plugin_data    = get_plugin_data( UCSCGIVING_PLUGIN_DIR . '/plugin.php' );
-		$plugin_version = $plugin_data['Version'];
-		if ( strpos( $current_screen->base, 'ucsc-giving-functionality-settings' ) === false ) {
+
+		// get_current_screen() returns null outside a real admin screen (ajax, customizer).
+		if ( ! $current_screen instanceof WP_Screen ) {
 			return;
 		}
-		wp_register_style( 'ucscgiving-cf-admin-settings', $settings_css, '', $plugin_version );
+
+		if ( false === strpos( $current_screen->base, 'ucsc-giving-functionality-settings' ) ) {
+			return;
+		}
+
+		$settings_css   = plugin_dir_url( __FILE__ ) . 'lib/css/admin-settings.css';
+		$plugin_data    = get_plugin_data( UCSCGIVING_PLUGIN_DIR . 'plugin.php' );
+		$plugin_version = $plugin_data['Version'];
+
+		wp_register_style( 'ucscgiving-cf-admin-settings', $settings_css, array(), $plugin_version );
 		wp_enqueue_style( 'ucscgiving-cf-admin-settings' );
 	}
 }
@@ -54,8 +64,8 @@ add_action( 'admin_enqueue_scripts', 'ucscgiving_enqueue_admin_styles' );
 /**
  * ACF JSON Save Point
  *
- * @param [type] $path
- * @return $path
+ * @param string $path Default ACF JSON save path.
+ * @return string Path to this plugin's acf-json directory.
  * @package ucsc-giving-functionality
  */
 function ucscgiving_acf_json_save_point( $path ) {
@@ -68,8 +78,8 @@ add_filter( 'acf/settings/save_json', 'ucscgiving_acf_json_save_point' );
 /**
  * ACF JSON Load Point
  *
- * @param [type] $paths
- * @return $paths
+ * @param array $paths Default ACF JSON load paths.
+ * @return array Load paths with this plugin's acf-json directory substituted in.
  * @package ucsc-giving-functionality
  */
 function ucscgiving_acf_json_load_point( $paths ) {
@@ -84,9 +94,8 @@ add_filter( 'acf/settings/load_json', 'ucscgiving_acf_json_load_point' );
 /**
  * Callback function to retrieve custom template content
  *
- * @param $template
- * @parameter $template
- * @return $template
+ * @param string $template Template filename, relative to lib/templates/.
+ * @return string Rendered template markup.
  * @package ucsc-giving-functionality
  */
 function ucscgiving_get_template_content( $template ) {
@@ -103,27 +112,27 @@ function ucscgiving_get_template_content( $template ) {
  */
 function ucscgiving_register_block_templates() {
 	$templates = array(
-		'archive-fund'       => array(
+		'archive-fund'        => array(
 			'title'       => __( 'Fund Archives', 'ucscgiving' ),
 			'description' => __( 'Displays the archive template for Giving Funds.', 'ucscgiving' ),
 		),
-		'taxonomy-area'      => array(
+		'taxonomy-area'       => array(
 			'title'       => __( 'Fund Area Archives', 'ucscgiving' ),
 			'description' => __( 'Displays the archive template for the Fund areas.', 'ucscgiving' ),
 		),
-		'taxonomy-fund-theme'     => array(
+		'taxonomy-fund-theme' => array(
 			'title'       => __( 'Fund Theme Archives', 'ucscgiving' ),
 			'description' => __( 'Displays the archive template for the Fund themes.', 'ucscgiving' ),
 		),
-		'taxonomy-fund-type' => array(
+		'taxonomy-fund-type'  => array(
 			'title'       => __( 'Fund Type Archives', 'ucscgiving' ),
 			'description' => __( 'Displays the archive template for the Fund types.', 'ucscgiving' ),
 		),
-		'taxonomy-keyword'   => array(
+		'taxonomy-keyword'    => array(
 			'title'       => __( 'Fund Keyword Archives', 'ucscgiving' ),
 			'description' => __( 'Displays the archive template for the Fund keywords.', 'ucscgiving' ),
 		),
-		'single-fund'        => array(
+		'single-fund'         => array(
 			'title'       => __( 'Single Funds Posts', 'ucscgiving' ),
 			'description' => __( 'Displays the single post template for Funds.', 'ucscgiving' ),
 		),


### PR DESCRIPTION
Fixes #120.

Seven correctness and hygiene defects in the plugin entrypoints, plus a broken lint setup. No behavior was added — this is all repair.

## The two that matter most

**`search_template` was hooked with `add_action()`.** It's a filter, so the callback ran but its return value was discarded. The fund-search template routing has been silently dead. (`lib/functions/general.php`)

**`get_current_screen()` was dereferenced unguarded.** It returns `null` in ajax and customizer contexts that still fire `admin_enqueue_scripts`, so `$current_screen->base` is a fatal on PHP 8. (`plugin.php`)

## The rest

| # | Fix | File |
|---|---|---|
| 3 | `get_plugin_data()` moved below the early return — it was parsing the plugin header on every admin page load and throwing the result away | `plugin.php` |
| 4 | Settings action link now targets `options-general.php` via `menu_page_url()`, matching where `add_options_page()` registers it, with a fallback so the link still renders if the page is unregistered | `lib/functions/settings.php` |
| 5 | `ucscgiving_link_filter()` reads `$post->ID` instead of `get_the_ID()` and a loop-less `get_field()`; also bails on non-`fund` post types before doing any ACF lookups | `lib/functions/general.php` |
| 6 | `esc_url()` replaces `esc_attr()` on the returned permalink; `get_term()` is checked for `null` as well as `WP_Error` | `lib/functions/general.php` |
| 7 | `defined( 'ABSPATH' ) || exit;` guards added | all three |

On #5 — `post_type_link` passes `$post` precisely so the filter doesn't need loop state. Reading `get_the_ID()` meant permalinks resolved against the wrong post (or nothing) anywhere outside the main loop: admin list tables, REST responses, feeds, sitemaps.

## Behavior change worth a look

A Standard fund whose `base_url` option is empty now keeps its normal permalink instead of returning `''`. Empty `href`s resolve to the current page, so the old behavior produced silently broken links. Flag it if anything downstream depended on the empty-string signal.

## Lint

`composer lint` was failing outright — `ERROR: You must supply at least one file or directory to process`, no path argument and no `<file>` element in the ruleset. Separately, WPCS 3.x dropped its JavaScript and CSS sniffs, so phpcs was reporting 20 bogus "tabs must be used" errors against `admin-settings.css` and `wp-plugin-version-updater.js`.

Scoped the scan to `extensions="php"`, added `<file>.</file>`, and excluded the file-docblock sniffs from `lib/templates/` since those are block markup rather than PHP source.

**35 errors / 19 warnings across 14 files → clean.**

## Verification

Tested against wp-env (WP 7.0.2, PHP 8.3.32, ACF Pro 6.8.4, `ucsc-2022` 5.1.1), which bind-mounts this repo live.

| Check | Result |
|---|---|
| `apply_filters('search_template', …)` return consumed | PASS — returns `''`, not the original path |
| `ucscgiving_enqueue_admin_styles()` with a `NULL` screen | PASS — returns cleanly, no fatal |
| Style enqueued on a non-settings screen | PASS — bails before the `get_plugin_data()` parse |
| `menu_page_url()` target | PASS — `options-general.php?page=…` |
| `get_permalink()` on a Standard fund with `$GLOBALS['post']` unset | PASS — `https://giving.ucsc.edu/donate/?fund=ABC123` |
| Endowment fund keeps its normal permalink | PASS |
| Regular post untouched | PASS |
| Empty `base_url` returns a real permalink, not `''` | PASS |
| `composer lint` | PASS — clean |
| `php -l` on all three edited files | PASS |

Test fixtures (2 fund posts, 2 `fund-type` terms, the `base_url` option) were created and torn down in a single atomic script; the environment was confirmed clean afterward.

## Not addressed

The block templates use relative `require 'parts/funds-search.php'`, which works only because PHP resolves relative includes against the calling file's directory. Functional but fragile — out of scope here, worth a follow-up to harden to `__DIR__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
