### PR TITLE
fix: handle multi-digit and prerelease versions in plugin header updater

### DIFF
--- a/wp-plugin-version-updater.js
+++ b/wp-plugin-version-updater.js
@@ -1,10 +1,37 @@
+/**
+ * commit-and-tag-version updater for the WordPress plugin header.
+ *
+ * Registered in package.json `bumpFiles` so the `Version:` header in
+ * plugin.php stays in step with package.json.
+ *
+ * Segments are `\d+` rather than a single `[0-9]`: a single-digit pattern
+ * matches the `0.5.1` prefix of `0.5.10` and rewrites only that prefix,
+ * silently corrupting the header. The optional prerelease suffix supports
+ * the `v*.*.*-rc.*` tags that .github/workflows/release.yml triggers on.
+ */
+
+const VERSION_PATTERN = /(Version:\s*)(\d+\.\d+\.\d+(?:-[\w.]+)?)/;
+
 module.exports.readVersion = function (contents) {
-  const capturingRegex = /Version: (?<vnum>[0-9]\.[0-9]\.[0-9])/;
-  const found = contents.match(capturingRegex);
-  return found.groups.vnum;
+  const found = contents.match(VERSION_PATTERN);
+
+  if (!found) {
+    throw new Error(
+      'wp-plugin-version-updater: no "Version:" header found. ' +
+        "Expected a line like ' * Version: 1.2.3'."
+    );
+  }
+
+  return found[2];
 };
 
-module.exports.writeVersion = function (_contents, version) {
-  const regex = /Version: (?<vnum>[0-9]\.[0-9]\.[0-9])/;
-  return _contents.replace(regex, "Version: " + version);
+module.exports.writeVersion = function (contents, version) {
+  if (!VERSION_PATTERN.test(contents)) {
+    throw new Error(
+      'wp-plugin-version-updater: no "Version:" header to update. ' +
+        "Refusing to write, as the plugin header would silently drift from package.json."
+    );
+  }
+
+  return contents.replace(VERSION_PATTERN, `$1${version}`);
 };


### PR DESCRIPTION
Fixes #123.

`wp-plugin-version-updater.js` matched the plugin version with a single `[0-9]` per segment, which breaks as soon as any segment reaches two digits. This is the `commit-and-tag-version` updater registered in `package.json` `bumpFiles`, so it is the only thing keeping the `Version:` header in `plugin.php` in step with `package.json`.

**Timing:** the plugin is at 0.5.8 and the next release is 0.5.9, so **0.5.10 — the first corrupting version — is two releases away.**

## Before / after

| Version | `readVersion()` before | after | `writeVersion()` before | after |
|---|---|---|---|---|
| `0.5.9` | `0.5.9` | `0.5.9` | ✅ | ✅ |
| `0.5.10` | **`0.5.1`** | `0.5.10` | ❌ **`Version: 0.5.110`** | ✅ |
| `0.10.0` | **throws** | `0.10.0` | ❌ silent no-op | ✅ |
| `10.0.0` | **throws** | `10.0.0` | ❌ silent no-op | ✅ |
| `0.5.9-rc.1` | **throws** | `0.5.9-rc.1` | ❌ silent no-op | ✅ |

Two distinct bugs were behind this:

1. **Silent corruption.** The regex matched the `0.5.1` prefix of `0.5.10`, and `writeVersion()` replaced only that prefix, leaving the trailing `0` behind. This is the dangerous one — it produces a plausible-looking but wrong version in the shipped plugin header, which WordPress uses for update checks.
2. **Hard crash / silent drift.** With a two-digit major or minor, `contents.match()` returned `null`; `readVersion()` threw `TypeError: Cannot read properties of null (reading 'groups')` and `writeVersion()` no-opped, so the header quietly stopped tracking `package.json`.

## Changes

- `\d+` per segment instead of `[0-9]`
- Optional `-[\w.]+` prerelease suffix. `.github/workflows/release.yml` already triggers on `v*.*.*-rc.*` tags, which the old pattern could not read or write at all — so RC releases were broken today, not just hypothetically.
- Capture the `Version: ` prefix so the replacement swaps the whole matched version rather than a leading substring — this is what actually prevents the `0.5.110` class of corruption.
- `\s*` after `Version:` to tolerate header whitespace
- `readVersion()` throws a descriptive error instead of a `TypeError` on `null`; `writeVersion()` refuses to write rather than silently no-op, so a malformed header fails loudly instead of drifting

The file stays CommonJS — `commit-and-tag-version` loads it via `require()`.

## Verification

Round-tripped `readVersion` / `writeVersion` across `0.5.8`, `0.5.9`, `0.5.10`, `0.10.0`, `10.0.0`, `1.2.3`, `12.34.56`, and `0.5.9-rc.1` — all read back correctly and rewrite cleanly. Malformed input now throws on both functions.

End-to-end `commit-and-tag-version --dry-run` against the real `plugin.php`:

```
✔ bumping version in package-lock.json from 0.5.8 to 0.5.9
✔ bumping version in package.json from 0.5.8 to 0.5.9
✔ bumping version in plugin.php from 0.5.8 to 0.5.9
✔ tagging release v0.5.9
```

No behavior change for the current version — this only fixes versions the old pattern could not represent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
