### PR TITLE
docs: add CLAUDE.md and ROADMAP.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+composer install      # PHP dev deps (PHPCS + WordPress Coding Standards)
+npm install           # Node dev deps (@wordpress/scripts, commit-and-tag-version)
+
+composer lint         # PHPCS across the repo
+composer lint-fix     # PHPCBF auto-fix
+
+npm run zip           # Build distributable ZIP (wp-scripts plugin-zip)
+npm run dryrun        # Preview version bump + changelog
+npm run release       # Tag a release and update CHANGELOG.md
+```
+
+There is **no automated test suite** — no PHPUnit, no wp-env config, no JS tests. `composer lint` is the only mechanical gate. Validate behavior by hand against a WordPress install with ACF Pro and the `ucsc-2022` theme active.
+
+## Repository shape
+
+This is a **standalone plugin repo**, not a site tree. There is no `wp-content/`, so tooling that scans for `wp-content/plugins/*` reports zero plugins here. The bootstrap is `plugin.php` at the repo root — not a file named after the plugin.
+
+The code is **procedural, not class-based**: `plugin.php` plus two files in `lib/functions/`. There are no namespaces, no autoloader, and no loader class. Everything is a top-level function registered with `add_action`/`add_filter` at file scope. Composer is dev-only (PHPCS); `vendor/` is never shipped or loaded at runtime.
+
+## External dependencies that are easy to miss
+
+Both of these live outside this repo and the plugin is substantially non-functional without them:
+
+- **ACF Pro** — declared via the `Requires Plugins: advanced-custom-fields-pro` header. Not on WP.org, so it cannot be installed automatically. All fund metadata flows through `get_field()`.
+- **The `ucsc-2022` theme** — two separate couplings:
+  - The `base_url` ACF field lives on the **`ucsc-theme-options` options page, which the theme registers**, not this plugin. Without the theme active, `get_field( 'base_url', 'option' )` returns nothing and every external fund URL silently collapses.
+  - Block templates reference the theme's template parts by name (`header`, `breadcrumbs`, `footer`, `theme":"ucsc-2022"`).
+
+## Architecture
+
+### Where the data model lives
+
+`acf-json/` is the **source of truth** for the `fund` post type, the four taxonomies (`area`, `fund-type`, `fund-theme`, `keyword`), and the field groups. None of it is registered in PHP. Field changes are made in the ACF admin UI and auto-export back to `acf-json/` via the save/load point filters in `plugin.php`. Editing these JSON files by hand is possible but the field `key` values (`field_*`, `group_*`) are referential — do not renumber them.
+
+### The fund linking model
+
+This is the core behavior. Funds carry a `fund-type` term and a `designation` post meta value:
+
+- **`Standard` fund type** → `ucscgiving_link_filter()` (on `post_type_link`) replaces the permalink with `base_url . designation`, sending visitors straight to the external giving form.
+- **Anything else** (the README calls these "Priority") → keeps its normal permalink and renders `single-fund.php`, where a **block binding** (`ucscgiving/fund-url`, registered in `general.php`) supplies the same computed URL to the "Give" button.
+
+So the same URL is computed by two different paths — `ucscgiving_fund_url()` for the binding, `ucscgiving_link_filter()` for the permalink. Changes to URL construction must be made in both or they will drift.
+
+`fund-type-term` is an ACF taxonomy field with `return_format = id`, so it yields a term ID that needs `get_term()` to resolve.
+
+### Templates are block markup, not PHP
+
+`lib/templates/*.php` are block-comment markup (`<!-- wp:… -->`) with a couple of `require` statements, not PHP source. They are read through `ucscgiving_get_template_content()` (output buffering) and handed to `register_block_template()` in `plugin.php`.
+
+Two consequences:
+- The `require 'parts/…'` calls inside them use **relative paths**, which resolve only because PHP falls back to the calling file's directory. Fragile — prefer `__DIR__` if touching them.
+- PHPCS file-docblock sniffs are excluded for `lib/templates/` in `.phpcs.xml.dist`, since a file docblock there is meaningless.
+
+## Conventions
+
+- **Prefix everything `ucscgiving_`** — functions, hooks, globals. PHPCS enforces this via `WordPress.NamingConventions.PrefixAllGlobals`.
+- **Text domain is `ucscgiving`** — enforced by PHPCS; a missing domain is a lint error.
+- PHPCS ruleset is `WordPress-Extra` + `WordPress-Docs`. The scan is **restricted to `extensions="php"`** because WPCS 3.x dropped its JS/CSS sniffs — do not re-widen it or `.css`/`.js` files will produce noise.
+- WordPress tabs for indentation in PHP, despite the `.editorconfig` (which is 4-space and applies mainly to non-PHP files).
+
+## Releases
+
+Releases are driven by **conventional commits** — `commit-and-tag-version` reads them to decide the bump, so the commit prefix is functional, not cosmetic (`fix:` → patch, `feat:` → minor, `chore:` → no bump).
+
+`npm run release` bumps `package.json`, `package-lock.json`, and the `Version:` header in `plugin.php` (via the custom updater `wp-plugin-version-updater.js`). Pushing a `v*.*.*` tag triggers `.github/workflows/release.yml`, which delegates to the shared `ucsc/actions` workflow and publishes `ucsc-giving-functionality-plugin.zip`.
+
+Only paths in the `files` array of `package.json` ship in the ZIP: `acf-json/`, `lib/`, `plugin.php`, `README.md`, `CHANGELOG.md`, `LICENSE`.
+
+The updater parses the header with a single regex covering multi-digit segments and an optional prerelease suffix, and throws rather than writing if the header is missing — keep both `readVersion` and `writeVersion` on that shared pattern so they cannot diverge.
+
+## Related
+
+`.github/copilot-instructions.md` covers much of the same ground for GitHub Copilot. Keep the two roughly in sync when conventions change; note it still refers to `standard-version`, which was replaced by `commit-and-tag-version`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,87 @@
+# Roadmap
+
+Engineering roadmap for the UCSC Giving Functionality plugin, derived from the state of the repository as of **2026-07-31** (v0.5.8).
+
+This is a technical roadmap, not a product plan. Items are grounded in open issues, in-flight pull requests, and observed characteristics of the codebase — it does not attempt to set feature direction, which is the University Advancement web team's call. Sequencing below reflects dependency order and risk, not committed dates.
+
+---
+
+## In flight
+
+| Item | Tracking | State |
+|---|---|---|
+| Double-save on Fund type change | [#3](https://github.com/ucsc/ucsc-giving-functionality/issues/3) | PR [#21](https://github.com/ucsc/ucsc-giving-functionality/pull/21) draft, **conflicting** |
+| `CLAUDE.md` / `ROADMAP.md` project context | [#122](https://github.com/ucsc/ucsc-giving-functionality/issues/122) | This change |
+
+### Needs a decision
+
+**PR #21 needs a rebase, or replacing.** It is a draft last touched 2026-03-18 and now conflicts with `main`: it edits `lib/functions/general.php`, and [#121](https://github.com/ucsc/ucsc-giving-functionality/pull/121) rewrote `ucscgiving_link_filter()` in that same file. Decide whether to rebase it or supersede it — see the next section, because the underlying problem is likely better solved at the data-model level than in the editor.
+
+### Recently landed
+
+- [#121](https://github.com/ucsc/ucsc-giving-functionality/pull/121) — seven correctness and hygiene fixes: a `search_template` filter that had never applied, an unguarded `get_current_screen()` fatal, and a permalink filter that read loop state instead of its own `$post` argument. Also repaired `composer lint`, which failed outright with no path argument.
+- [#124](https://github.com/ucsc/ucsc-giving-functionality/pull/124) — the plugin header version updater matched a single digit per segment, so it would have silently corrupted the `Version:` header at 0.5.10 and could not parse the `v*.*.*-rc.*` tags `release.yml` already triggers on.
+
+---
+
+## 1. Resolve the dual source of truth for fund type
+
+**The highest-value architectural item.** Issue #3 describes the symptom — a Fund must be saved twice for a type change to stick — but the cause is structural: *fund type is stored in two places at once.*
+
+- The `fund-type` taxonomy holds the term.
+- The ACF field `fund-type-term` (`field_67cc7f695ce26`) is a taxonomy field with `save_terms = 1` and `load_terms = 1`, so ACF **also** reads and writes that same term.
+
+Two systems own the same value and write it on different passes of the save cycle, which is what produces the double-save. Downstream code inherits the ambiguity: `ucscgiving_link_filter()` reads the ACF field and resolves it with `get_term()`, so the linking behavior depends on which writer won.
+
+Worth deciding explicitly:
+
+- **Taxonomy as the single source of truth** — drop `save_terms`/`load_terms`, or drop the ACF field entirely and edit the term through the standard taxonomy UI. Simplest model; requires a migration path for existing posts and a rewrite of the `get_field()` reads.
+- **ACF field as the single source of truth** — keep the field, make the taxonomy purely derived. Keeps the curated editor UX.
+
+Either way this should be settled before more logic is layered on top of fund type, and it likely subsumes PR #21.
+
+## 2. Reduce coupling to the `ucsc-2022` theme
+
+The plugin is not currently installable on its own. Two hard dependencies on the theme, neither declared anywhere a site admin would see:
+
+- The `base_url` ACF field lives on the **`ucsc-theme-options` options page registered by the theme**, not by this plugin. Without the theme active, `get_field( 'base_url', 'option' )` returns nothing and every external fund URL silently collapses to an empty or partial link.
+- Block templates reference the theme's template parts by name (`header`, `breadcrumbs`, `footer`, `"theme":"ucsc-2022"`).
+
+Options range from cheap to thorough:
+
+- **Cheap:** detect the missing options page and surface an admin notice rather than failing silently.
+- **Middle:** move `base_url` into this plugin's own settings page — which already exists but is display-only — so the plugin owns the value it depends on.
+- **Thorough:** make template-part references resilient so the templates degrade rather than break under a different theme.
+
+The middle option also gives the existing settings page a reason to exist beyond displaying the plugin description.
+
+## 3. Establish a test harness
+
+There is currently **no automated test coverage of any kind** — no PHPUnit, no `.wp-env.json`, no JS tests. `composer lint` is the only mechanical gate, and it checks style, not behavior.
+
+This is what makes items 1 and 2 risky: the fund-linking logic has several branches (fund type, empty `base_url`, missing designation, non-`fund` post types, in-loop vs out-of-loop) that today can only be verified by hand.
+
+Suggested order:
+
+1. Add a `.wp-env.json` so contributors get a reproducible environment from the repo instead of configuring one externally.
+2. Add PHPUnit with a small suite around `ucscgiving_link_filter()` and `ucscgiving_fund_url()` — the two functions that independently compute the same URL and are the most likely to drift.
+3. Wire lint and tests into CI on pull requests. Today `.github/workflows/release.yml` only runs on tags, so **nothing validates a PR automatically.**
+
+## 4. Harden packaging and templates
+
+- **Relative `require` in block templates.** `lib/templates/*.php` use `require 'parts/…'`, which resolves only because PHP falls back to the calling file's directory. Change to `__DIR__`-relative paths. Low effort, removes a latent break.
+- **Single URL-construction path.** `ucscgiving_fund_url()` (block binding) and `ucscgiving_link_filter()` (permalink) build the same URL independently. Extract one helper so they cannot diverge.
+
+## 5. Maintenance
+
+- **Dependabot: 104 open alerts, all `development` scope.** Zero production-scope alerts, and the shipped ZIP contains only `acf-json/`, `lib/`, `plugin.php`, and docs — no `node_modules`. **Nothing here reaches a WordPress site.** The cluster is the `@wordpress/scripts` transitive tree (axios, webpack-dev-server, node-forge, handlebars). Bumping `@wordpress/scripts` should clear most of it. Real, but a housekeeping item rather than a security incident.
+- **`.github/copilot-instructions.md` has drifted** — it still documents `standard-version`, replaced by `commit-and-tag-version` in a19905c. Keep it in sync with `CLAUDE.md` when conventions change.
+- **Automated daily-repo-status issues** accounted for most of the closed-issue history (#94–#118). If that workflow is still active, consider whether the signal justifies the noise in the issue tracker.
+
+---
+
+## Non-goals
+
+- Rewriting the plugin as class-based / namespaced. The procedural structure is small and consistent; churn here would buy little.
+- Registering the post type and taxonomies in PHP. `acf-json/` is the working source of truth and the ACF admin round-trips to it.
+- Shipping a build step for front-end assets. The plugin ships no JavaScript, and `@wordpress/scripts` is used only for `plugin-zip`.


### PR DESCRIPTION
Fixes #122.

Adds two documentation files. No plugin behavior changes.

## `CLAUDE.md`

Durable project context for Claude Code, so it isn't re-derived every session. Scoped to things that take reading several files to work out, rather than anything visible from a directory listing:

- This is a **standalone plugin repo** with no `wp-content/` tree, so plugin-detection tooling reports zero plugins here; the bootstrap is `plugin.php` at the root.
- The code is **procedural** — no namespaces, no autoloader, Composer is dev-only.
- **`acf-json/` is the source of truth** for the `fund` post type, the four taxonomies, and the field groups. None of it is registered in PHP, and the `field_*`/`group_*` keys are referential.
- The **`ucsc-2022` theme registers the `ucsc-theme-options` page that `base_url` lives on** — not this plugin. Without the theme active, `get_field( 'base_url', 'option' )` returns nothing and every external fund URL silently collapses. This coupling is invisible from inside this repo.
- The fund URL is **computed independently in two places** — `ucscgiving_fund_url()` for the block binding and `ucscgiving_link_filter()` for the permalink — so changes to URL construction must be made in both or they drift.
- **Templates are block markup, not PHP source**, which explains both the relative-`require` fragility and the PHPCS file-docblock exclusion.
- **Conventional commits are functional**, since `commit-and-tag-version` reads them to pick the bump.

Where `.github/copilot-instructions.md` already covered ground accurately, that content is carried forward rather than restated differently. The `Related` section notes those instructions still refer to `standard-version`, replaced by `commit-and-tag-version` in a19905c.

## `ROADMAP.md`

An **engineering** roadmap derived from the current state of the repository — open issues, in-flight PRs, and observed characteristics. It deliberately does not set feature direction or dates; that's the team's call.

The largest item is **the dual source of truth for fund type**. Issue #3 is filed as a double-save annoyance, but the cause is structural: the `fund-type` taxonomy holds the term *and* the ACF field `fund-type-term` is configured `save_terms = 1` / `load_terms = 1`, so ACF reads and writes that same term. Two systems own one value and write it on different passes of the save cycle. Downstream code inherits the ambiguity — `ucscgiving_link_filter()` resolves the ACF field with `get_term()`, so linking behavior depends on which writer won. This likely subsumes PR #21 rather than PR #21 fixing it.

Other items, in dependency order: reducing the `ucsc-2022` theme coupling, establishing a test harness (there is currently no automated coverage of any kind, and **nothing runs on pull requests** — `release.yml` only triggers on tags), hardening the relative `require` paths, and consolidating the duplicated URL construction.

Two findings worth flagging from the research:

- **PR #21 now conflicts with `main`** (`mergeable: CONFLICTING`). It edits `lib/functions/general.php`, and #121 rewrote `ucscgiving_link_filter()` in that same file. It needs a rebase decision either way.
- **The 104 Dependabot alerts are all `development` scope — zero production.** The shipped ZIP contains no `node_modules`, so none of it reaches a WordPress site. It's the `@wordpress/scripts` transitive tree. Real housekeeping, but not a security incident.

A short **Non-goals** section records what is deliberately not planned — a class-based rewrite, PHP-registered post types, a front-end build step — since those tend to accumulate by default otherwise.

## Notes

Rebased onto `713f81b` after #124 merged, and the references to that now-closed work were updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
