### PR TITLE
ci: run PHPCS on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+# Continuous integration — runs on every pull request.
+#
+# release.yml only fires on v*.*.* tags, so before this workflow nothing
+# validated a pull request. PHPCS is currently the repo's only mechanical
+# gate; a test suite is tracked separately in issue #128 and should be added
+# as another step in this same job.
+
+name: CI
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+
+permissions:
+    contents: read
+
+# A new push to the same ref makes the in-flight run redundant.
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    lint:
+        name: PHPCS (PHP ${{ matrix.php-version }})
+        runs-on: ubuntu-latest
+
+        strategy:
+            # Report every failing version, not just the first.
+            fail-fast: false
+            matrix:
+                # 8.1 is the declared floor and what ucsc/wp-dev.ucsc pins.
+                # 8.4 is the forward-compatibility check.
+                php-version: ['8.1', '8.4']
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6.0.2
+
+            - name: Set up PHP
+              uses: shivammathur/setup-php@2.37.2
+              with:
+                  php-version: ${{ matrix.php-version }}
+                  coverage: none
+                  tools: composer
+
+            - name: Install Composer dependencies
+              run: composer install --no-progress --no-interaction
+
+            - name: Run PHPCS
+              run: composer lint

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -79,7 +79,8 @@
 	the wiki:
 	https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_supported_wp_version" value="4.9"/>
+	<!-- Match the `Requires at least` header in plugin.php. -->
+	<config name="minimum_supported_wp_version" value="6.5"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ npm run release       # Tag a release and update CHANGELOG.md
 
 There is **no automated test suite** — no PHPUnit, no wp-env config, no JS tests. `composer lint` is the only mechanical gate. Validate behavior by hand against a WordPress install with ACF Pro and the `ucsc-2022` theme active.
 
+`composer lint` runs on every pull request via `.github/workflows/ci.yml` (PHP 8.1 and 8.4), so a style regression fails the PR. `release.yml` still only fires on tags.
+
 ## Repository shape
 
 This is a **standalone plugin repo**, not a site tree. There is no `wp-content/`, so tooling that scans for `wp-content/plugins/*` reports zero plugins here. The bootstrap is `plugin.php` at the repo root — not a file named after the plugin.

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
     "name": "ucsc/giving-functionality",
     "description": "Adds custom functionality to UCSC Giving Website.",
     "license": "GPL-3.0-or-later",
+    "require": {
+        "php": ">=8.1"
+    },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "wp-coding-standards/wpcs": "^3.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "486fc1c7e6ca06471bb03abf80a4fb08",
+    "content-hash": "a59790ac10e6d16913b4008791f71312",
     "packages": [],
     "packages-dev": [
         {
@@ -429,7 +429,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.1"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/plugin.php
+++ b/plugin.php
@@ -17,7 +17,7 @@
  * @package ucsc-giving-functionality
  */
 
-defined( 'ABSPATH' ) || exit;
+defined('ABSPATH') || exit;
 
 // Set plugin directory and base name.
 define( 'UCSCGIVING_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); // Path to plugin directory.

--- a/plugin.php
+++ b/plugin.php
@@ -5,6 +5,7 @@
  * Description: Adds custom functionality to UCSC Giving Website.
  * Version: 0.5.8
  * Requires at least: 6.5.0
+ * Requires PHP: 8.1
  * Author: UC Santa Cruz
  * Author URI: https://github.com/ucsc
  * License: GPL3

--- a/plugin.php
+++ b/plugin.php
@@ -17,7 +17,7 @@
  * @package ucsc-giving-functionality
  */
 
-defined('ABSPATH') || exit;
+defined( 'ABSPATH' ) || exit;
 
 // Set plugin directory and base name.
 define( 'UCSCGIVING_PLUGIN_DIR', plugin_dir_path( __FILE__ ) ); // Path to plugin directory.


### PR DESCRIPTION
Closes #127.

`release.yml` only fires on `v*.*.*` tags, so nothing validated a pull request. This adds `.github/workflows/ci.yml` running `composer lint` on `pull_request` and on pushes to `main`.

## Changes

- **`.github/workflows/ci.yml`** — PHPCS on a PHP 8.1 / 8.4 matrix, `fail-fast: false` so both versions report. Pinned to `actions/checkout@v6.0.2` to match the pin in `ucsc/actions`, and `shivammathur/setup-php@2.37.2`. Concurrency group cancels superseded runs.
- **PHP floor declared** — there was none anywhere: `composer.json` had no `require.php` and `plugin.php` had no `Requires PHP:` header, only `Requires at least: 6.5.0` for WordPress. Now `>=8.1` / `Requires PHP: 8.1`, matching the PHP 8.1 that `ucsc/wp-dev.ucsc` pins. `composer.lock` is the refreshed content-hash and platform block only.
- **`.phpcs.xml.dist`** — `minimum_supported_wp_version` 4.9 → 6.5, matching the plugin header. Raising it changes which deprecation sniffs fire; **lint stays clean at 6.5**, verified locally, which was the condition for including it here.
- **`CLAUDE.md`** — records that lint now gates PRs, since that file explicitly documents what validates changes.

## Verification

`composer lint` passes clean locally at PHP 8.5.4 with the raised WPCS target. All dev dependencies support PHP >= 7.2, so the 8.1 job installs fine.

Red/green verification of the gate itself follows on this PR: a deliberate style violation is pushed to confirm the check fails, then reverted to confirm it passes.

## Note on the release bump

Typed `ci:`, which `commit-and-tag-version` treats as **no version bump**. The `Requires PHP:` header does change a shipped file, so it will ride along with the next `fix:`/`feat:` release rather than cutting one now. Retitle to `fix:` before merging if you'd rather have 0.5.9 carry it immediately.

## Follow-on

#128 adds `composer test` as another step in this same job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)