### PR TITLE
test: add PHPUnit unit-test harness with stubbed WordPress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 # Continuous integration — runs on every pull request.
 #
 # release.yml only fires on v*.*.* tags, so before this workflow nothing
-# validated a pull request. PHPCS is currently the repo's only mechanical
-# gate; a test suite is tracked separately in issue #128 and should be added
-# as another step in this same job.
+# validated a pull request. Runs PHPCS for style and PHPUnit for behaviour.
+#
+# The PHPUnit suite is unit-level: tests/bootstrap.php stubs WordPress, so no
+# WordPress install, database, ACF Pro licence or ucsc-2022 theme is needed
+# here. See issue #129 for why full integration testing is out of scope.
 
 name: CI
 
@@ -22,8 +24,8 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    lint:
-        name: PHPCS (PHP ${{ matrix.php-version }})
+    checks:
+        name: PHP ${{ matrix.php-version }}
         runs-on: ubuntu-latest
 
         strategy:
@@ -42,6 +44,7 @@ jobs:
               uses: shivammathur/setup-php@2.37.2
               with:
                   php-version: ${{ matrix.php-version }}
+                  extensions: mbstring
                   coverage: none
                   tools: composer
 
@@ -50,3 +53,6 @@ jobs:
 
             - name: Run PHPCS
               run: composer lint
+
+            - name: Run PHPUnit
+              run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ node_modules
 
 # Editor directories
 .vscode/
+
+# PHPUnit
+.phpunit.cache/
+.phpunit.result.cache

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -53,7 +53,14 @@
 	<rule ref="WordPress-Docs"/>
 
 	<!-- Add in some extra rules from other standards. -->
-	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
+		<!--
+		The WordPress stand-ins in tests/stubs.php mirror core signatures so
+		the plugin can be loaded, and deliberately ignore most of what they
+		are handed.
+		-->
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
 	<rule ref="Generic.Commenting.Todo"/>
 
 	<!-- Check for PHP cross-version compatibility. -->
@@ -97,6 +104,12 @@
 				<element value="ucscgiving"/>
 			</property>
 		</properties>
+		<!--
+		tests/ declares stand-ins for WordPress core and ACF functions
+		(get_field(), add_action(), …) plus PHPUnit test classes. Neither can
+		carry the plugin prefix and still do its job.
+		-->
+		<exclude-pattern>/tests/*</exclude-pattern>
 	</rule>
 
 	<!--

--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,20 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "phpunit/phpunit": "^10.5",
         "wp-coding-standards/wpcs": "^3.1"
     },
     "scripts": {
         "lint": "./vendor/bin/phpcs",
-        "lint-fix": "./vendor/bin/phpcbf --extensions=php ."
+        "lint-fix": "./vendor/bin/phpcbf --extensions=php .",
+        "test": "./vendor/bin/phpunit"
     },
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "platform": {
+            "php": "8.1"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a59790ac10e6d16913b4008791f71312",
+    "content-hash": "c249c4df7173ea7e91c60b83ca83714b",
     "packages": [],
     "packages-dev": [
         {
@@ -104,22 +104,257 @@
             "time": "2026-05-06T08:26:05+00:00"
         },
         {
-            "name": "phpcsstandards/phpcsextra",
-            "version": "1.5.0",
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "b598aa890815b8df16363271b659d73280129101"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
-                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.2.0",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
@@ -183,20 +418,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-12T23:06:57+00:00"
+            "time": "2026-07-27T11:13:17+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -276,7 +511,1374 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.64",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.5",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.64"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:50:35+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:25:16+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -358,17 +1960,67 @@
             "time": "2025-11-04T16:30:35+00:00"
         },
         {
-            "name": "wp-coding-standards/wpcs",
-            "version": "3.3.0",
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
@@ -377,9 +2029,9 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
-                "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -421,7 +2073,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-25T12:08:04+00:00"
+            "time": "2026-07-27T11:53:23+00:00"
         }
     ],
     "aliases": [],
@@ -433,5 +2085,8 @@
         "php": ">=8.1"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.1"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	cacheDirectory=".phpunit.cache"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	failOnWarning="true"
+	failOnNotice="true"
+>
+	<testsuites>
+		<testsuite name="ucsc-giving-functionality">
+			<directory suffix="Test.php">./tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * Dual mode, following tests/bootstrap.php in ucsc/ucsc-blocks:
+ *
+ * - Integration: when WP_TESTS_DIR points at a wordpress-develop checkout's
+ *   tests/phpunit directory, the real WordPress test suite is loaded and the
+ *   plugin is activated inside it.
+ * - Standalone (the default): tests/stubs.php supplies the minimum WordPress
+ *   stand-ins needed to load the plugin, so the suite runs on bare PHP plus
+ *   Composer — no WordPress, no database, no ACF Pro licence and no
+ *   ucsc-2022 theme.
+ *
+ * Run:
+ *   composer test
+ *   WP_TESTS_DIR=/path/to/wordpress-develop/tests/phpunit composer test
+ *
+ * @package ucsc-giving-functionality
+ */
+
+$ucscgiving_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( false === $ucscgiving_tests_dir || '' === $ucscgiving_tests_dir ) {
+	$ucscgiving_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+if ( file_exists( $ucscgiving_tests_dir . '/includes/functions.php' ) ) {
+
+	require_once $ucscgiving_tests_dir . '/includes/functions.php';
+
+	/**
+	 * Load the plugin under test inside the WordPress test suite.
+	 *
+	 * @return void
+	 */
+	function ucscgiving_manually_load_plugin() {
+		require dirname( __DIR__ ) . '/plugin.php';
+	}
+
+	tests_add_filter( 'muplugins_loaded', 'ucscgiving_manually_load_plugin' );
+
+	require $ucscgiving_tests_dir . '/includes/bootstrap.php';
+
+} else {
+	// Standalone mode. The stubs must be in place before plugin.php loads:
+	// plugin.php calls plugin_dir_path() and plugin_basename() at file scope,
+	// and both plugin.php and lib/functions/*.php register hooks at file
+	// scope via add_action()/add_filter().
+	require_once __DIR__ . '/doubles/class-ucscgiving-test-state.php';
+	require_once __DIR__ . '/doubles/class-wp-error.php';
+	require_once __DIR__ . '/doubles/class-wp-term.php';
+	require_once __DIR__ . '/stubs.php';
+	require_once dirname( __DIR__ ) . '/plugin.php';
+}

--- a/tests/doubles/class-ucscgiving-test-state.php
+++ b/tests/doubles/class-ucscgiving-test-state.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Mutable state backing the WordPress function stubs.
+ *
+ * @package ucsc-giving-functionality
+ */
+
+/**
+ * Values the WordPress stand-ins in tests/stubs.php read from.
+ *
+ * Tests set what they need in setUp() and call reset() so nothing leaks
+ * between cases.
+ */
+final class UCSCGiving_Test_State {
+
+	/**
+	 * ACF field values, keyed by field selector.
+	 *
+	 * @var array<string,mixed>
+	 */
+	public static $fields = array();
+
+	/**
+	 * Post meta values, keyed by "{post_id}:{meta_key}".
+	 *
+	 * @var array<string,mixed>
+	 */
+	public static $meta = array();
+
+	/**
+	 * Term objects, or WP_Error, keyed by term ID.
+	 *
+	 * @var array<int,mixed>
+	 */
+	public static $terms = array();
+
+	/**
+	 * Value returned by is_search().
+	 *
+	 * @var bool
+	 */
+	public static $is_search = false;
+
+	/**
+	 * Query vars, keyed by name.
+	 *
+	 * @var array<string,mixed>
+	 */
+	public static $query_vars = array();
+
+	/**
+	 * Value returned by locate_template().
+	 *
+	 * @var string
+	 */
+	public static $located_template = '';
+
+	/**
+	 * Value returned by get_the_ID().
+	 *
+	 * @var int
+	 */
+	public static $current_post_id = 0;
+
+	/**
+	 * Restore every stub to its default.
+	 *
+	 * @return void
+	 */
+	public static function reset() {
+		self::$fields           = array();
+		self::$meta             = array();
+		self::$terms            = array();
+		self::$is_search        = false;
+		self::$query_vars       = array();
+		self::$located_template = '';
+		self::$current_post_id  = 0;
+	}
+}

--- a/tests/doubles/class-wp-error.php
+++ b/tests/doubles/class-wp-error.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * WP_Error stand-in.
+ *
+ * @package ucsc-giving-functionality
+ */
+
+if ( ! class_exists( 'WP_Error' ) ) {
+
+	/**
+	 * Minimal WP_Error.
+	 *
+	 * Exists so the is_wp_error() stub can keep core's semantics of testing
+	 * the object's type rather than a marker property.
+	 */
+	class WP_Error {
+
+		/**
+		 * Error code.
+		 *
+		 * @var string
+		 */
+		public $code;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $code Error code.
+		 */
+		public function __construct( $code = '' ) {
+			$this->code = $code;
+		}
+	}
+}

--- a/tests/doubles/class-wp-term.php
+++ b/tests/doubles/class-wp-term.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * WP_Term stand-in.
+ *
+ * @package ucsc-giving-functionality
+ */
+
+if ( ! class_exists( 'WP_Term' ) ) {
+
+	/**
+	 * Minimal WP_Term.
+	 *
+	 * The permalink filter tests its resolved term with `instanceof WP_Term`,
+	 * so this class has to exist under its real name rather than being faked
+	 * with stdClass.
+	 */
+	class WP_Term {
+
+		/**
+		 * Term ID.
+		 *
+		 * @var int
+		 */
+		public $term_id;
+
+		/**
+		 * Term name.
+		 *
+		 * @var string
+		 */
+		public $name;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param int    $term_id Term ID.
+		 * @param string $name    Term name.
+		 */
+		public function __construct( $term_id = 0, $name = '' ) {
+			$this->term_id = $term_id;
+			$this->name    = $name;
+		}
+	}
+}

--- a/tests/php/AcfJsonPointsTest.php
+++ b/tests/php/AcfJsonPointsTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tests for the ACF JSON save and load points.
+ *
+ * @package ucsc-giving-functionality
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the two filters that keep acf-json/ inside this plugin.
+ */
+class AcfJsonPointsTest extends TestCase {
+
+	/**
+	 * The save point always points at this plugin's acf-json directory.
+	 *
+	 * @return void
+	 */
+	public function test_save_point_returns_plugin_acf_json_directory() {
+		$this->assertSame(
+			UCSCGIVING_PLUGIN_DIR . 'acf-json',
+			ucscgiving_acf_json_save_point( '/some/other/path' )
+		);
+	}
+
+	/**
+	 * The load point drops ACF's own default path and appends this plugin's.
+	 *
+	 * @return void
+	 */
+	public function test_load_point_replaces_the_default_path() {
+		$paths = ucscgiving_acf_json_load_point( array( '/acf/default', '/another/path' ) );
+
+		$this->assertNotContains( '/acf/default', $paths );
+		$this->assertContains( '/another/path', $paths );
+		$this->assertContains( UCSCGIVING_PLUGIN_DIR . 'acf-json', $paths );
+	}
+
+	/**
+	 * The plugin's path is appended last, so it wins on load order.
+	 *
+	 * @return void
+	 */
+	public function test_load_point_appends_plugin_path_last() {
+		$paths = array_values( ucscgiving_acf_json_load_point( array( '/acf/default' ) ) );
+
+		$this->assertSame( UCSCGIVING_PLUGIN_DIR . 'acf-json', end( $paths ) );
+	}
+
+	/**
+	 * Documents a latent fragility rather than asserting desired behaviour:
+	 * the function removes index 0 specifically, so if ACF ever passes an
+	 * array that is not zero-indexed, nothing is removed and the default
+	 * path survives alongside the plugin's.
+	 *
+	 * @return void
+	 */
+	public function test_load_point_does_not_remove_a_non_zero_indexed_default() {
+		$paths = ucscgiving_acf_json_load_point( array( 3 => '/acf/default' ) );
+
+		$this->assertContains( '/acf/default', $paths );
+		$this->assertContains( UCSCGIVING_PLUGIN_DIR . 'acf-json', $paths );
+	}
+}

--- a/tests/php/FundSearchTemplateTest.php
+++ b/tests/php/FundSearchTemplateTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Tests for ucscgiving_fund_search_template().
+ *
+ * This is the search_template filter that #121 found had never applied. The
+ * cases below are the regression guard: PHPCS cannot catch a filter that
+ * silently does nothing, but these will.
+ *
+ * @package ucsc-giving-functionality
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers routing fund search results through the fund archive template.
+ */
+class FundSearchTemplateTest extends TestCase {
+
+	/**
+	 * The template path handed to the filter.
+	 *
+	 * @var string
+	 */
+	private $template = '/themes/ucsc-2022/search.php';
+
+	/**
+	 * Reset the WordPress stubs before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		UCSCGiving_Test_State::reset();
+	}
+
+	/**
+	 * A fund search falls through to the archive template.
+	 *
+	 * @return void
+	 */
+	public function test_returns_located_template_for_fund_search() {
+		UCSCGiving_Test_State::$is_search               = true;
+		UCSCGiving_Test_State::$query_vars['post_type'] = 'fund';
+		UCSCGiving_Test_State::$located_template        = '';
+
+		$this->assertSame( '', ucscgiving_fund_search_template( $this->template ) );
+	}
+
+	/**
+	 * Searches for other post types keep the resolved search template.
+	 *
+	 * @return void
+	 */
+	public function test_leaves_other_post_type_searches_untouched() {
+		UCSCGiving_Test_State::$is_search               = true;
+		UCSCGiving_Test_State::$query_vars['post_type'] = 'post';
+
+		$this->assertSame( $this->template, ucscgiving_fund_search_template( $this->template ) );
+	}
+
+	/**
+	 * Outside a search the filter does nothing.
+	 *
+	 * @return void
+	 */
+	public function test_leaves_non_search_requests_untouched() {
+		UCSCGiving_Test_State::$query_vars['post_type'] = 'fund';
+
+		$this->assertSame( $this->template, ucscgiving_fund_search_template( $this->template ) );
+	}
+
+	/**
+	 * The filter returns whatever locate_template() resolves, so it is that
+	 * call — not the incoming path — that decides the result.
+	 *
+	 * @return void
+	 */
+	public function test_returns_whatever_locate_template_resolves() {
+		UCSCGiving_Test_State::$is_search               = true;
+		UCSCGiving_Test_State::$query_vars['post_type'] = 'fund';
+		UCSCGiving_Test_State::$located_template        = '/themes/ucsc-2022/archive-fund.php';
+
+		$this->assertSame(
+			'/themes/ucsc-2022/archive-fund.php',
+			ucscgiving_fund_search_template( $this->template )
+		);
+	}
+}

--- a/tests/php/FundSearchVariationTest.php
+++ b/tests/php/FundSearchVariationTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Tests for ucscgiving_create_fund_search_variation().
+ *
+ * @package ucsc-giving-functionality
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the core/search block variation scoped to the fund post type.
+ */
+class FundSearchVariationTest extends TestCase {
+
+	/**
+	 * Reset the WordPress stubs before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		UCSCGiving_Test_State::reset();
+	}
+
+	/**
+	 * Build a block type object.
+	 *
+	 * The filter only reads ->name and has no type hint, so a plain object
+	 * is enough; no WP_Block_Type stand-in is needed.
+	 *
+	 * @param string $name Block type name.
+	 * @return object
+	 */
+	private function block_type( $name ) {
+		return (object) array( 'name' => $name );
+	}
+
+	/**
+	 * The variation is appended for core/search.
+	 *
+	 * @return void
+	 */
+	public function test_appends_variation_to_core_search() {
+		$variations = ucscgiving_create_fund_search_variation( array(), $this->block_type( 'core/search' ) );
+
+		$this->assertCount( 1, $variations );
+		$this->assertSame( 'fund-search', $variations[0]['name'] );
+		$this->assertSame( 'fund', $variations[0]['attributes']['query']['post_type'] );
+	}
+
+	/**
+	 * Existing variations are preserved, not replaced.
+	 *
+	 * @return void
+	 */
+	public function test_preserves_existing_variations() {
+		$existing = array( array( 'name' => 'existing' ) );
+
+		$variations = ucscgiving_create_fund_search_variation( $existing, $this->block_type( 'core/search' ) );
+
+		$this->assertCount( 2, $variations );
+		$this->assertSame( 'existing', $variations[0]['name'] );
+		$this->assertSame( 'fund-search', $variations[1]['name'] );
+	}
+
+	/**
+	 * Other block types are returned untouched.
+	 *
+	 * @return void
+	 */
+	public function test_leaves_other_block_types_untouched() {
+		$existing = array( array( 'name' => 'existing' ) );
+
+		$variations = ucscgiving_create_fund_search_variation( $existing, $this->block_type( 'core/paragraph' ) );
+
+		$this->assertSame( $existing, $variations );
+	}
+}

--- a/tests/php/FundUrlTest.php
+++ b/tests/php/FundUrlTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Tests for ucscgiving_fund_url().
+ *
+ * @package ucsc-giving-functionality
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the block-binding callback that builds the external giving URL.
+ */
+class FundUrlTest extends TestCase {
+
+	/**
+	 * Reset the WordPress stubs before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		UCSCGiving_Test_State::reset();
+	}
+
+	/**
+	 * The happy path: base URL plus the fund's designation code.
+	 *
+	 * @return void
+	 */
+	public function test_concatenates_base_url_and_designation() {
+		UCSCGiving_Test_State::$fields['base_url']     = 'https://give.example.edu/fund/';
+		UCSCGiving_Test_State::$current_post_id        = 42;
+		UCSCGiving_Test_State::$meta['42:designation'] = 'ABC123';
+
+		$this->assertSame( 'https://give.example.edu/fund/ABC123', ucscgiving_fund_url() );
+	}
+
+	/**
+	 * With no designation the base URL is returned on its own.
+	 *
+	 * @return void
+	 */
+	public function test_returns_base_url_when_designation_is_missing() {
+		UCSCGiving_Test_State::$fields['base_url'] = 'https://give.example.edu/fund/';
+		UCSCGiving_Test_State::$current_post_id    = 42;
+
+		$this->assertSame( 'https://give.example.edu/fund/', ucscgiving_fund_url() );
+	}
+
+	/**
+	 * Without base_url there is nothing to build from.
+	 *
+	 * This is the ucsc-2022 coupling: base_url lives on an options page the
+	 * theme registers, so it is empty whenever that theme is not active.
+	 *
+	 * @return void
+	 */
+	public function test_returns_empty_string_when_base_url_is_missing() {
+		UCSCGiving_Test_State::$current_post_id        = 42;
+		UCSCGiving_Test_State::$meta['42:designation'] = 'ABC123';
+
+		$this->assertSame( '', ucscgiving_fund_url() );
+	}
+
+	/**
+	 * Neither value present.
+	 *
+	 * @return void
+	 */
+	public function test_returns_empty_string_when_nothing_is_set() {
+		$this->assertSame( '', ucscgiving_fund_url() );
+	}
+}

--- a/tests/php/LinkFilterTest.php
+++ b/tests/php/LinkFilterTest.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Tests for ucscgiving_link_filter().
+ *
+ * @package ucsc-giving-functionality
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the post_type_link filter that points Standard funds at the
+ * external giving site and leaves everything else alone.
+ */
+class LinkFilterTest extends TestCase {
+
+	/**
+	 * The permalink handed to the filter.
+	 *
+	 * @var string
+	 */
+	private $permalink = 'https://example.test/fund/some-fund/';
+
+	/**
+	 * Reset the WordPress stubs before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		UCSCGiving_Test_State::reset();
+	}
+
+	/**
+	 * Build a post object.
+	 *
+	 * The filter only reads ->ID and ->post_type and has no type hint, so a
+	 * plain object is enough; no WP_Post stand-in is needed.
+	 *
+	 * @param int    $post_id   Post ID.
+	 * @param string $post_type Post type.
+	 * @return object
+	 */
+	private function make_post( $post_id, $post_type ) {
+		return (object) array(
+			'ID'        => $post_id,
+			'post_type' => $post_type,
+		);
+	}
+
+	/**
+	 * Build a fund post and point the stubs at a fund-type term.
+	 *
+	 * @param int    $post_id   Post ID.
+	 * @param string $term_name Fund type term name.
+	 * @return object
+	 */
+	private function make_fund( $post_id = 7, $term_name = 'Standard' ) {
+		UCSCGiving_Test_State::$fields['fund-type-term'] = 99;
+		UCSCGiving_Test_State::$terms[99]                = new WP_Term( 99, $term_name );
+
+		return $this->make_post( $post_id, 'fund' );
+	}
+
+	/**
+	 * Anything that is not a fund is passed straight through.
+	 *
+	 * @return void
+	 */
+	public function test_leaves_non_fund_post_types_untouched() {
+		$post = $this->make_post( 7, 'post' );
+
+		$this->assertSame( $this->permalink, ucscgiving_link_filter( $this->permalink, $post ) );
+	}
+
+	/**
+	 * A fund with no fund-type term keeps its own permalink.
+	 *
+	 * @return void
+	 */
+	public function test_returns_permalink_when_fund_type_term_is_missing() {
+		$post = $this->make_post( 7, 'fund' );
+
+		$this->assertSame( $this->permalink, ucscgiving_link_filter( $this->permalink, $post ) );
+	}
+
+	/**
+	 * A WP_Error from get_term() must not become a broken URL.
+	 *
+	 * @return void
+	 */
+	public function test_returns_permalink_when_get_term_returns_wp_error() {
+		UCSCGiving_Test_State::$fields['fund-type-term'] = 99;
+		UCSCGiving_Test_State::$terms[99]                = new WP_Error( 'invalid_taxonomy' );
+
+		$post = $this->make_post( 7, 'fund' );
+
+		$this->assertSame( $this->permalink, ucscgiving_link_filter( $this->permalink, $post ) );
+	}
+
+	/**
+	 * A term ID that resolves to nothing is also non-fatal.
+	 *
+	 * @return void
+	 */
+	public function test_returns_permalink_when_term_does_not_resolve() {
+		UCSCGiving_Test_State::$fields['fund-type-term'] = 99;
+
+		$post = $this->make_post( 7, 'fund' );
+
+		$this->assertSame( $this->permalink, ucscgiving_link_filter( $this->permalink, $post ) );
+	}
+
+	/**
+	 * Non-Standard funds ("Priority") render their own single template.
+	 *
+	 * @return void
+	 */
+	public function test_returns_permalink_for_non_standard_fund_type() {
+		UCSCGiving_Test_State::$fields['base_url']    = 'https://give.example.edu/fund/';
+		UCSCGiving_Test_State::$meta['7:designation'] = 'ABC123';
+
+		$post = $this->make_fund( 7, 'Priority' );
+
+		$this->assertSame( $this->permalink, ucscgiving_link_filter( $this->permalink, $post ) );
+	}
+
+	/**
+	 * Without base_url the permalink is left alone rather than truncated.
+	 *
+	 * @return void
+	 */
+	public function test_returns_permalink_when_base_url_is_missing() {
+		UCSCGiving_Test_State::$meta['7:designation'] = 'ABC123';
+
+		$post = $this->make_fund();
+
+		$this->assertSame( $this->permalink, ucscgiving_link_filter( $this->permalink, $post ) );
+	}
+
+	/**
+	 * The happy path: a Standard fund links out to the giving site.
+	 *
+	 * @return void
+	 */
+	public function test_returns_external_url_for_standard_fund() {
+		UCSCGiving_Test_State::$fields['base_url']    = 'https://give.example.edu/fund/';
+		UCSCGiving_Test_State::$meta['7:designation'] = 'ABC123';
+
+		$post = $this->make_fund();
+
+		$this->assertSame(
+			'https://give.example.edu/fund/ABC123',
+			ucscgiving_link_filter( $this->permalink, $post )
+		);
+	}
+
+	/**
+	 * Documents current behaviour: a Standard fund with no designation code
+	 * still links out, to the bare base URL.
+	 *
+	 * @return void
+	 */
+	public function test_returns_bare_base_url_when_designation_is_missing() {
+		UCSCGiving_Test_State::$fields['base_url'] = 'https://give.example.edu/fund/';
+
+		$post = $this->make_fund();
+
+		$this->assertSame(
+			'https://give.example.edu/fund/',
+			ucscgiving_link_filter( $this->permalink, $post )
+		);
+	}
+
+	/**
+	 * The filter reads its own $post argument rather than loop state, so a
+	 * different current post must not change the result. This is the
+	 * regression guard for the permalink fix in #121.
+	 *
+	 * @return void
+	 */
+	public function test_reads_the_post_argument_not_loop_state() {
+		UCSCGiving_Test_State::$fields['base_url']    = 'https://give.example.edu/fund/';
+		UCSCGiving_Test_State::$meta['7:designation'] = 'ABC123';
+		UCSCGiving_Test_State::$meta['8:designation'] = 'WRONG';
+		UCSCGiving_Test_State::$current_post_id       = 8;
+
+		$post = $this->make_fund( 7 );
+
+		$this->assertSame(
+			'https://give.example.edu/fund/ABC123',
+			ucscgiving_link_filter( $this->permalink, $post )
+		);
+	}
+}

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * WordPress function stand-ins for standalone test runs.
+ *
+ * Loaded only when no WordPress test suite is available. Each stub is the
+ * smallest thing that lets the plugin load and its functions be exercised;
+ * none of them reproduce WordPress behaviour faithfully. Values the tests
+ * need to vary live on UCSCGiving_Test_State.
+ *
+ * Note that esc_url() here is a pass-through: these tests assert how the
+ * fund URL is composed, not how WordPress escapes it.
+ *
+ * @package ucsc-giving-functionality
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	/**
+	 * No-op. The plugin registers hooks at file scope.
+	 *
+	 * @param string   $hook          Hook name.
+	 * @param callable $callback      Callback.
+	 * @param int      $priority      Priority.
+	 * @param int      $accepted_args Accepted argument count.
+	 * @return bool
+	 */
+	function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	/**
+	 * No-op. The plugin registers filters at file scope.
+	 *
+	 * @param string   $hook          Hook name.
+	 * @param callable $callback      Callback.
+	 * @param int      $priority      Priority.
+	 * @param int      $accepted_args Accepted argument count.
+	 * @return bool
+	 */
+	function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'plugin_dir_path' ) ) {
+	/**
+	 * Directory of the given file, with a trailing slash.
+	 *
+	 * @param string $file File path.
+	 * @return string
+	 */
+	function plugin_dir_path( $file ) {
+		return rtrim( dirname( $file ), '/' ) . '/';
+	}
+}
+
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+	/**
+	 * Stand-in plugin URL.
+	 *
+	 * @param string $file File path.
+	 * @return string
+	 */
+	function plugin_dir_url( $file ) {
+		return 'https://example.test/wp-content/plugins/' . basename( dirname( $file ) ) . '/';
+	}
+}
+
+if ( ! function_exists( 'plugin_basename' ) ) {
+	/**
+	 * Plugin basename, as "directory/file.php".
+	 *
+	 * @param string $file File path.
+	 * @return string
+	 */
+	function plugin_basename( $file ) {
+		return basename( dirname( $file ) ) . '/' . basename( $file );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * Pass-through translation.
+	 *
+	 * @param string $text   Text to translate.
+	 * @param string $domain Text domain.
+	 * @return string
+	 */
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_html__' ) ) {
+	/**
+	 * Pass-through translation.
+	 *
+	 * @param string $text   Text to translate.
+	 * @param string $domain Text domain.
+	 * @return string
+	 */
+	function esc_html__( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	/**
+	 * Pass-through. These tests assert URL composition, not escaping.
+	 *
+	 * @param string $url URL.
+	 * @return string
+	 */
+	function esc_url( $url ) {
+		return $url;
+	}
+}
+
+if ( ! function_exists( 'get_field' ) ) {
+	/**
+	 * ACF get_field() stand-in.
+	 *
+	 * @param string     $selector Field name.
+	 * @param int|string $post_id  Post ID, or 'option'.
+	 * @return mixed
+	 */
+	function get_field( $selector, $post_id = false ) {
+		return UCSCGiving_Test_State::$fields[ $selector ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'get_post_meta' ) ) {
+	/**
+	 * Post meta stand-in.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $key     Meta key.
+	 * @param bool   $single  Whether to return a single value.
+	 * @return mixed
+	 */
+	function get_post_meta( $post_id, $key = '', $single = false ) {
+		return UCSCGiving_Test_State::$meta[ $post_id . ':' . $key ] ?? '';
+	}
+}
+
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid -- Must match core's get_the_ID().
+if ( ! function_exists( 'get_the_ID' ) ) {
+	/**
+	 * Current post ID stand-in.
+	 *
+	 * @return int
+	 */
+	function get_the_ID() {
+		return UCSCGiving_Test_State::$current_post_id;
+	}
+}
+// phpcs:enable WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+
+if ( ! function_exists( 'get_term' ) ) {
+	/**
+	 * Term lookup stand-in.
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param string $taxonomy Taxonomy name.
+	 * @return mixed
+	 */
+	function get_term( $term_id, $taxonomy = '' ) {
+		return UCSCGiving_Test_State::$terms[ $term_id ] ?? null;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	/**
+	 * Whether the given value is a WP_Error.
+	 *
+	 * @param mixed $thing Value to check.
+	 * @return bool
+	 */
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'is_search' ) ) {
+	/**
+	 * Whether the current query is a search.
+	 *
+	 * @return bool
+	 */
+	function is_search() {
+		return UCSCGiving_Test_State::$is_search;
+	}
+}
+
+if ( ! function_exists( 'get_query_var' ) ) {
+	/**
+	 * Query var stand-in.
+	 *
+	 * @param string $query_var Query var name.
+	 * @param mixed  $fallback  Value to return when the var is not set.
+	 * @return mixed
+	 */
+	function get_query_var( $query_var, $fallback = '' ) {
+		return UCSCGiving_Test_State::$query_vars[ $query_var ] ?? $fallback;
+	}
+}
+
+if ( ! function_exists( 'locate_template' ) ) {
+	/**
+	 * Template lookup stand-in.
+	 *
+	 * @param string|array $template_names Template names.
+	 * @param bool         $load           Whether to load the file.
+	 * @param bool         $load_once      Whether to require_once.
+	 * @return string
+	 */
+	function locate_template( $template_names, $load = false, $load_once = true ) {
+		return UCSCGiving_Test_State::$located_template;
+	}
+}


### PR DESCRIPTION
Closes #128. First automated behavioural coverage in the repo — 24 tests, 31 assertions.

## Framing

These are **unit tests with stubbed WordPress functions, not integration tests.** No WordPress install, no database, no ACF Pro licence, no `ucsc-2022` theme. They run on bare PHP + Composer, so they add nothing to how anyone runs WordPress locally.

That's deliberate, not a compromise. `ucscgiving_fund_url()` reads `get_field( 'base_url', 'option' )` — an ACF **Pro** options page registered by the theme — so integration-testing the very functions #128 names would need a licence key as a CI secret. See #129.

## Layout — follows `ucsc/ucsc-blocks`

| Path | Purpose |
|---|---|
| `phpunit.xml.dist` | bootstrap + testsuite, `suffix="Test.php"` |
| `tests/bootstrap.php` | same dual-mode `WP_TESTS_DIR` switch as ucsc-blocks |
| `tests/stubs.php` | WordPress function stand-ins (functions only) |
| `tests/doubles/class-*.php` | `UCSCGiving_Test_State`, `WP_Term`, `WP_Error` |
| `tests/php/*Test.php` | the tests |

## Coverage

- **`ucscgiving_link_filter()`** — all six branches: non-`fund` post type, missing term, `WP_Error` from `get_term()`, unresolvable term, non-`Standard` type, empty `base_url`, plus the happy path and a guard that it reads its `$post` argument rather than loop state (the #121 fix).
- **`ucscgiving_fund_url()`** — base + designation, base only, neither.
- **`ucscgiving_fund_search_template()`** — regression guard for the `search_template` filter #121 found had never applied. PHPCS cannot catch a filter that silently does nothing; this can.
- **`ucscgiving_create_fund_search_variation()`** — appends for `core/search`, preserves existing variations, ignores other block types.
- **ACF JSON points** — including a test that *documents* rather than endorses the `unset( $paths[0] )` fragility: a non-zero-indexed array leaves the default path in place.

## Verification

Run in throwaway containers, so nothing was installed on the dev machine:

| Check | Result |
|---|---|
| PHPUnit on `php:8.1-cli` (the floor) | ✅ OK (24 tests, 31 assertions) |
| PHPUnit on `php:8.4-cli` | ✅ OK (24 tests, 31 assertions) |
| `composer lint` | ✅ clean |
| `npm run zip` → test files in ZIP | ✅ 0 |

**Mutation-checked so the suite isn't vacuous.** Reverting the `'Standard'` guard and reintroducing the #121 loop-state bug produced **4 failures**, including `test_reads_the_post_argument_not_loop_state`. Both mutations were then reverted.

## Notes

- **PHPUnit pinned to `^10.5`** — 11 requires PHP 8.2 and 12 requires 8.3, both above the 8.1 floor declared in #127. `ucsc-blocks` pins `^10` too, so this matches by constraint and by convention.
- **`composer config.platform.php` pinned to `8.1`** so dependency resolution matches the declared floor instead of whatever PHP the developer happens to run.
- **PHPCS on `tests/`** — handled with two path-scoped rule exclusions (`PrefixAllGlobals`, `UnusedFunctionParameter`) and one inline ignore for `get_the_ID()`, following how the ruleset already scopes exclusions for `lib/templates/`. Rather than excluding four more structural sniffs, the stubs were restructured: classes moved into properly named `class-*.php` files, and the `WP_Post`/`WP_Block_Type` stubs dropped entirely in favour of plain objects, since neither call site type-hints.
- **`ext-mbstring` is now a contributor prerequisite** (PHPUnit requires it). CI installs it explicitly via `setup-php`.
- The CI job was renamed `lint` → `checks` since it now does more than lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)