### PR TITLE
fix: complete the Causes to Themes taxonomy rename

### DIFF
--- a/acf-json/post_type_67b609ae42d72.json
+++ b/acf-json/post_type_67b609ae42d72.json
@@ -76,7 +76,7 @@
     "taxonomies": [
         "keyword",
         "area",
-        "cause"
+        "fund-theme"
     ],
     "has_archive": true,
     "has_archive_slug": "funds",
@@ -92,5 +92,5 @@
     "delete_with_user": false,
     "register_meta_box_cb": "",
     "enter_title_here": "",
-    "modified": 1741197835
+    "modified": 1785879461
 }

--- a/lib/templates/parts/funds-search.php
+++ b/lib/templates/parts/funds-search.php
@@ -3,5 +3,5 @@
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:categories {"taxonomy":"area","displayAsDropdown":true} /-->
 
-<!-- wp:categories {"taxonomy":"cause","displayAsDropdown":true} /--></div>
+<!-- wp:categories {"taxonomy":"fund-theme","displayAsDropdown":true} /--></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Closes #140.

`dc93e42` ("Change taxonomy Causes to Themes #9", 2025-06-28) renamed the taxonomy but touched **only** the taxonomy JSON. Two references to the dead `cause` slug were left behind, and no `cause` taxonomy has existed since.

## Changes

**1. `lib/templates/parts/funds-search.php`** — the user-visible half:

```diff
-<!-- wp:categories {"taxonomy":"cause","displayAsDropdown":true} /-->
+<!-- wp:categories {"taxonomy":"fund-theme","displayAsDropdown":true} /-->
```

That part is required by `taxonomy-fund-type.php` and `taxonomy-fund-theme.php`, so **every Fund Type and Fund Theme term archive** rendered a categories dropdown against a taxonomy that doesn't exist. The section is meant to show Areas and Themes side by side; it could only ever show Areas.

**2. `acf-json/post_type_67b609ae42d72.json`** — `taxonomies: ["keyword", "area", "cause"]` → `"fund-theme"`.

## The decision #140 asked for

The issue left open whether to rename this entry or simply drop it. **I renamed it**, on the grounds that it's the change `dc93e42` should have made — dropping it is a separate judgement about what that array is for, and expands scope.

Worth knowing either way: **that array is not what attaches taxonomies here.** Each taxonomy JSON carries its own `object_type: ["fund"]`, which is why `fund-type` works despite never appearing in the list. So this is corrected metadata, not a functional fix. One-line change if you'd rather drop the entry.

I did *not* add the two missing taxonomies (`fund-type`, `fund-theme` is now there, `fund-type` still isn't) — that inconsistency predates this and isn't part of the rename.

## ACF sync timestamp

Bumped `modified` on the post type JSON. Without it, ACF sees the file as older than any database copy and won't offer the sync, so the fix would ship in the ZIP but never reach an install that has the post type stored in the DB.

The diff is deliberately two lines — I first rewrote the file with a JSON serialiser and it unescaped `wp\/v2` to `wp/v2`, which would have flipped back the next time ACF saved and created diff noise. Redone with targeted edits so the rest of the file is byte-identical.

## Verification

Rendered both affected templates through `ucscgiving_get_template_content()`:

```
taxonomy-fund-theme.php     3491 bytes  cause=gone  fund-theme=yes  area=yes
taxonomy-fund-type.php      3491 bytes  cause=gone  fund-theme=yes  area=yes
```

No `cause` reference remains anywhere in `acf-json/`, `lib/` or `plugin.php`. JSON validates. `composer lint` clean, 30 tests green.

Safe to hand-edit, unlike #133: `core/categories` is a dynamic block — a self-closing comment with no saved HTML — so changing an attribute can't desynchronise it from a `save()` output or trigger block-validation errors.

**Worth a browser check before merge:** `/fund-theme/<term>/` should now show two dropdowns, Areas and Themes. That also confirms whether it resolves the warning you saw — since the exact text was never captured, #140 was a confirmed bug on that page rather than a confirmed explanation of that message. If a warning persists, it's something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)