### PR TITLE
docs: correct the standard-version drift and the daily-repo-status bullet

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ WordPress plugin that creates a custom post type "Fund" for the UCSC Giving webs
 ### Install Dependencies
 ```bash
 composer install       # Install PHP dev dependencies (PHPCS + WordPress Coding Standards)
-npm install            # Install Node dev dependencies (@wordpress/scripts, standard-version)
+npm install            # Install Node dev dependencies (@wordpress/scripts, commit-and-tag-version)
 ```
 
 ## Architecture & Key Components
@@ -54,7 +54,7 @@ Configured via ACF JSON files in `acf-json/`:
 ## Development Workflows
 
 ### Version Management
-Uses `standard-version` for automated releases:
+Uses `commit-and-tag-version` for automated releases, driven by **conventional commits** — the commit prefix is functional, not cosmetic (`fix:` → patch, `feat:` → minor, `chore:`/`ci:`/`docs:` → no bump):
 ```bash
 npm run release        # Create new version tag and update CHANGELOG.md
 npm run dryrun         # Preview version bump and changelog changes
@@ -117,7 +117,7 @@ Fund search results are returned using the archive template via `ucscgiving_fund
 - **Template parts (reusable blocks)**: `lib/templates/parts/`
 - **Field changes**: Manage via ACF admin (auto-exports to `acf-json/`)
 - **Styling**: Admin CSS in `lib/css/admin-settings.css`
-- **Version bumping**: `wp-plugin-version-updater.js` + `package.json` `standard-version` config
+- **Version bumping**: `wp-plugin-version-updater.js` + `package.json` `commit-and-tag-version` config
 
 ## Dependencies
 - WordPress 6.5+ (required for Block Bindings API via `register_block_bindings_source`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,4 +82,4 @@ The updater parses the header with a single regex covering multi-digit segments 
 
 ## Related
 
-`.github/copilot-instructions.md` covers much of the same ground for GitHub Copilot. Keep the two roughly in sync when conventions change; note it still refers to `standard-version`, which was replaced by `commit-and-tag-version`.
+`.github/copilot-instructions.md` covers much of the same ground for GitHub Copilot. Keep the two roughly in sync when conventions change.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,8 +117,8 @@ The suite covers functions that are pure once WordPress is stubbed. Anything nee
   [#137](https://github.com/ucsc/ucsc-giving-functionality/issues/137) bumped `@wordpress/scripts` 30 → 34 and applied the non-breaking fixes, taking `npm audit` from 63 to 29 and clearing every critical. What remains is held behind `semver-major` bumps inside that tree — `adm-zip`, `markdown-it`/`linkify-it`, `minimatch`, and `webpack-dev-server` via `sockjs` — so it cannot be cleared without either forcing breaking upgrades or waiting for upstream. Not worth forcing, given zero production exposure.
 
   The durable fix is to stop depending on that tree at all: `plugin-zip` is the only thing used from it. A smaller dependency, or a short zip script, would remove the entire alert surface permanently. Worth considering the next time this backlog becomes annoying.
-- **`.github/copilot-instructions.md` has drifted** — it still documents `standard-version`, replaced by `commit-and-tag-version` in a19905c. Keep it in sync with `CLAUDE.md` when conventions change.
-- **Automated daily-repo-status issues** accounted for most of the closed-issue history (#94–#118). If that workflow is still active, consider whether the signal justifies the noise in the issue tracker.
+- **Keep `.github/copilot-instructions.md` in sync with `CLAUDE.md`.** The two cover much of the same ground for different agents, and the copilot file drifts more easily because nothing reads it during normal work. It documented `standard-version` for four months after a19905c replaced it with `commit-and-tag-version` on 2026-03-18; corrected in [#138](https://github.com/ucsc/ucsc-giving-functionality/issues/138). Worth a glance whenever a convention, command or dependency changes.
+- **The daily-repo-status workflow has been removed**, and with it the bulk of the closed-issue history it generated (#94–#118). `.github/workflows/` now holds only `ci.yml` and `release.yml`. The `daily-status` and `report` labels are kept deliberately — 88 closed issues carry each, and deleting a label strips it from every issue, which would make that history unfilterable for no benefit.
 
 ---
 


### PR DESCRIPTION
Closes #138. Six lines across three files.

## 1. `standard-version` → `commit-and-tag-version`

`a19905c` made the swap on **2026-03-18**; `copilot-instructions.md` kept documenting the old tool for four months. That matters more than a typo, because the file exists to instruct a coding agent — one acting on it would go looking for config that isn't there.

Three references corrected. While in that section I also made it state that the commit prefix is **functional, not cosmetic** (`fix:` → patch, `feat:` → minor, `chore:`/`ci:`/`docs:` → no bump), which `CLAUDE.md` says and the copilot file didn't. That's the part an agent would actually get wrong.

`CLAUDE.md`'s "Related" section carried a note flagging this drift; removed, since there's no longer drift to flag.

## 2. The daily-repo-status bullet

It asked whether that workflow was still worth its noise. It's gone — `.github/workflows/` holds only `ci.yml` and `release.yml` — so the question is answered.

**I replaced the bullet rather than deleting it**, which is a small departure from the issue's wording. It now records the outcome instead of posing the question, because of the labels decision below. Easy to delete the line entirely if you'd rather §5 not carry settled items.

## 3. The labels decision the issue asked for

**`daily-status` and `report` stay.** I checked before deciding: **88 closed issues carry each of them.** Deleting a label removes it from every issue permanently, so it would make that whole history unfilterable and buy nothing. Recorded in §5 so it isn't proposed again.

## 4. §5's own drift bullet

It described the problem this PR fixes, so it would have been stale on merge. Rewritten as a standing reminder to keep the two agent files in sync — with the observation that the copilot file drifts more easily precisely because nothing reads it during normal work, which is why it went four months unnoticed.

## Verification

Docs only. No `standard-version` reference remains anywhere outside `node_modules`. `a19905c` confirmed as the right commit and date (I'd first written "roughly a year", which was wrong — it's four months). `composer lint` clean, 30 tests green, and the ZIP job will confirm packaging is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)