### PR TITLE
fix: make fund type a single choice, defaulting to Priority

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,7 @@ npm install            # Install Node dev dependencies (@wordpress/scripts, comm
 - **Templates**: `lib/templates/` contains block-based templates for single funds and taxonomy archives
 - **Template Parts**: `lib/templates/parts/` contains reusable template partials (`funds-search.php`, `post-query-funds.php`), pulled in with `__DIR__`-relative `require`
 - **Styles**: `lib/css/admin-settings.css` - Admin settings page styles
+- **Scripts**: `lib/js/fund-type-radio.js` - the only browser JavaScript. Hand-written against the `wp.*` globals, no build step and no bundler; nothing lints it, so match the surrounding style by hand. Both this and the CSS are enqueued from `plugin.php`, because `plugin_dir_url( __FILE__ )` only resolves correctly from there.
 - **ACF Configuration**: `acf-json/` directory stores Advanced Custom Fields configuration as JSON
 
 ### Block Bindings Integration
@@ -49,6 +50,7 @@ Configured via ACF JSON files in `acf-json/`:
 - **Post Type**: `fund` with custom labels and permalink structure (`post_type_67b609ae42d72.json`)
 - **Taxonomies**: area, fund-theme, fund-type, keyword — all attached to the `fund` post type
 - **`fund-type` owns fund type outright** (#3): `show_ui: 1` and `show_in_rest: 1`, edited through the standard taxonomy panel. Do not add an ACF taxonomy field targeting `fund-type` — that reintroduces the second writer behind the old double-save bug.
+- **A fund is Standard or Priority, never both.** `lib/js/fund-type-radio.js` makes the editor panel a radio via the `editor.PostTaxonomyType` filter (`meta_box_cb` does not work — the block editor discards taxonomy meta boxes unconditionally), and `ucscgiving_enforce_single_fund_type()` on `set_object_terms` normalises Quick Edit, Bulk Edit, REST and WP-CLI writes. Do not move that to `save_post`: the REST controller fires it before `handle_terms()` writes the terms.
 - **Field Groups**: Fund designation code, button text (`group_67b76c100ca57.json`, `group_67c4adfce3d52.json`)
 - **Meta Fields**: `designation` (post meta), `button_text` (post meta), `base_url` (global ACF option)
 
@@ -119,6 +121,7 @@ Fund search results are returned using the archive template via `ucscgiving_fund
 - **Template parts (reusable blocks)**: `lib/templates/parts/`
 - **Field changes**: Manage via ACF admin (auto-exports to `acf-json/`)
 - **Styling**: Admin CSS in `lib/css/admin-settings.css`
+- **Block editor behavior**: `lib/js/fund-type-radio.js`, enqueued from `plugin.php`
 - **Version bumping**: `wp-plugin-version-updater.js` + `package.json` `commit-and-tag-version` config
 
 ## Dependencies
@@ -134,4 +137,5 @@ The suite stubs WordPress (`tests/bootstrap.php`) rather than running inside it,
 - Verify block bindings render correct URLs in the block editor and on the front end
 - Check the "Fund Search" block variation appears in the block inserter
 - Validate ACF fields save correctly and that values appear in templates
+- Confirm the Fund Type panel renders as radio buttons and a type change sticks on a single save — `lib/js/fund-type-radio.js` has no automated coverage
 - Run `composer lint` and `composer test` before committing; CI runs both and will fail the PR otherwise

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Both paths compose that URL through **`ucscgiving_build_fund_url( $post_id )`** 
 
 Two consequences worth remembering:
 
--   Fund type is a **checkbox list** in the editor, so a Fund can carry both `Standard` and `Priority`. `has_term()` matches and the fund links out. Deliberate trade-off, pinned by a test in `tests/php/LinkFilterTest.php`.
+-   **A fund is Standard or Priority, never both**, and two separate things keep it that way. `lib/js/fund-type-radio.js` replaces the editor's checkbox list with a radio via the `editor.PostTaxonomyType` filter — the only supported route, since core registers taxonomy meta boxes with `__back_compat_meta_box => true` unconditionally and the block editor therefore ignores `meta_box_cb`. `ucscgiving_enforce_single_fund_type()` on `set_object_terms` covers everything the editor does not: Quick Edit, Bulk Edit, REST, WP-CLI. Use `set_object_terms`, **not `save_post`** — the REST controller fires `save_post` before `handle_terms()` writes the terms.
 -   `acf-json/` round-trips through the ACF admin UI, so a re-export could silently add a field back. `tests/php/FundTypeSourceOfTruthTest.php` asserts against the JSON to catch that.
 
 ### Templates are block markup, not PHP
@@ -81,8 +81,9 @@ Two consequences:
 
 -   **Prefix everything `ucscgiving_`** — functions, hooks, globals. PHPCS enforces this via `WordPress.NamingConventions.PrefixAllGlobals`.
 -   **Text domain is `ucscgiving`** — enforced by PHPCS; a missing domain is a lint error.
--   PHPCS ruleset is `WordPress-Extra` + `WordPress-Docs`. The scan is **restricted to `extensions="php"`** because WPCS 3.x dropped its JS/CSS sniffs — do not re-widen it or `.css`/`.js` files will produce noise.
+-   PHPCS ruleset is `WordPress-Extra` + `WordPress-Docs`. The scan is **restricted to `extensions="php"`** because WPCS 3.x dropped its JS/CSS sniffs — do not re-widen it or `.css`/`.js` files will produce noise. Consequence: **nothing lints `lib/js/`** — there is no ESLint config and no JS lint script. Match the surrounding style by hand.
 -   WordPress tabs for indentation in PHP, despite the `.editorconfig` (which is 4-space and applies mainly to non-PHP files).
+-   **Asset enqueues belong in `plugin.php`.** Both of them build their URL with `plugin_dir_url( __FILE__ )`, which resolves to the plugin root only because `plugin.php` sits there. The same call from `lib/functions/` silently yields a broken URL — it would need `plugins_url( …, UCSCGIVING_PLUGIN_DIR . 'plugin.php' )` instead.
 
 ## Releases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,8 @@ Both paths compose that URL through **`ucscgiving_build_fund_url( $post_id )`** 
 Two consequences worth remembering:
 
 -   **A fund is Standard or Priority, never both**, and two separate things keep it that way. `lib/js/fund-type-radio.js` replaces the editor's checkbox list with a radio via the `editor.PostTaxonomyType` filter — the only supported route, since core registers taxonomy meta boxes with `__back_compat_meta_box => true` unconditionally and the block editor therefore ignores `meta_box_cb`. `ucscgiving_enforce_single_fund_type()` on `set_object_terms` covers everything the editor does not: Quick Edit, Bulk Edit, REST, WP-CLI. Use `set_object_terms`, **not `save_post`** — the REST controller fires `save_post` before `handle_terms()` writes the terms.
--   `acf-json/` round-trips through the ACF admin UI, so a re-export could silently add a field back. `tests/php/FundTypeSourceOfTruthTest.php` asserts against the JSON to catch that.
+-   **A new fund defaults to `Priority`**, via the taxonomy's `default_term`. WordPress resolves that with `term_exists( name, taxonomy )` and creates a new term when it misses, so renaming the `Priority` term without updating `acf-json/` produces a duplicate rather than an error.
+-   `acf-json/` round-trips through the ACF admin UI, so a re-export could silently add a field back. `tests/php/FundTypeSourceOfTruthTest.php` asserts against the JSON to catch that, along with the default term.
 
 ### Templates are block markup, not PHP
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,9 +42,13 @@ No data migration was needed. `load_terms = 1` meant `get_field( 'fund-type-term
 
 `ucscgiving_link_filter()` reads `has_term( 'Standard', 'fund-type', $post->ID )` instead of `get_field()` + `get_term()`. That removed the `WP_Error` and `instanceof WP_Term` guards along with their tests, and with them the last need for the `WP_Term` and `WP_Error` doubles in `tests/doubles/` — the harness got smaller.
 
-### What it costs
+### Keeping the choice either/or
 
-WordPress renders a hierarchical taxonomy as a **checkbox list**, not a radio. An editor can therefore tick Standard *and* Priority on the same Fund, where the ACF field structurally could not; `has_term()` then matches and the fund links out. `LinkFilterTest::test_links_out_when_standard_is_one_of_several_terms()` pins that behaviour rather than pretending it cannot happen. If it becomes a real problem, the options are a `save_post` guard or a custom `meta_box_cb` rendering radios.
+A fund is Standard *or* Priority, never both. The ACF radio enforced that structurally; WordPress renders a hierarchical taxonomy as a **checkbox list**, which does not. Two things close that gap.
+
+**In the editor**, `lib/js/fund-type-radio.js` swaps the checkbox list for a `RadioControl` through the `editor.PostTaxonomyType` filter. That filter is the only supported route: core registers every taxonomy meta box with `__back_compat_meta_box => true` **unconditionally**, so a custom `meta_box_cb` is discarded by the block editor and would only ever appear in the classic editor. This is the plugin's **first browser JavaScript** — hand-written against the `wp.*` globals, no build step, no bundler, consistent with the non-goal below. Translatable strings are passed in from PHP via `wp_localize_script()` so the `ucscgiving` text domain stays where PHPCS enforces it.
+
+**Everywhere else**, `ucscgiving_enforce_single_fund_type()` on `set_object_terms` trims fund-type to one term. Quick Edit and Bulk Edit still render checkboxes, and REST clients, WP-CLI and imports never touch the admin at all. `set_object_terms` is the hook rather than `save_post` because `WP_REST_Posts_Controller::update_item()` runs `wp_update_post()` — and therefore `save_post` — *before* `handle_terms()` writes the terms; it would inspect the terms before they existed. This is a normaliser over the single store, not a third writer arbitrating between two.
 
 Also new to the admin, both by-products of `show_ui`: a **Fund Types** submenu for term management, and a fund-type control in Quick Edit.
 
@@ -52,7 +56,10 @@ Also new to the admin, both by-products of `show_ui`: a **Fund Types** submenu f
 
 ### Still hand-verified
 
-The save cycle itself. The PHPUnit suite stubs WordPress, so nothing automated exercises `handle_terms()` — changing a Fund's type and saving once has to be checked against an install with ACF Pro and the `ucsc-2022` theme active. See §3.
+Two things, both beyond a WordPress-stubbing suite:
+
+- **The save cycle.** Nothing automated exercises `handle_terms()` — changing a Fund's type and saving once has to be checked against an install with ACF Pro and the `ucsc-2022` theme active. See §3.
+- **The radio control.** There is no JavaScript test harness and none is proposed. `SingleFundTypeTest` covers the PHP normaliser, which is the half that guarantees the data; the editor affordance is checked by hand.
 
 ## 2. Reduce coupling to the `ucsc-2022` theme
 
@@ -74,7 +81,7 @@ The middle option also gives the existing settings page a reason to exist beyond
 **Largely done.** [#127](https://github.com/ucsc/ucsc-giving-functionality/pull/130) and [#128](https://github.com/ucsc/ucsc-giving-functionality/pull/131) landed on 2026-08-04. What exists now:
 
 - **PR checks.** `.github/workflows/ci.yml` runs `composer lint` and `composer test` on every pull request, across PHP 8.1 and 8.4. Previously `release.yml` only fired on tags, so nothing validated a PR at all.
-- **A PHPUnit suite** — 36 tests over `ucscgiving_link_filter()` (every branch), `ucscgiving_build_fund_url()`, `ucscgiving_fund_url()`, `ucscgiving_fund_search_template()`, `ucscgiving_create_fund_search_variation()`, the two ACF JSON points, and the fund-type source-of-truth invariants from §1.
+- **A PHPUnit suite** — 43 tests over `ucscgiving_link_filter()` (every branch), `ucscgiving_build_fund_url()`, `ucscgiving_fund_url()`, `ucscgiving_fund_search_template()`, `ucscgiving_create_fund_search_variation()`, `ucscgiving_enforce_single_fund_type()`, the two ACF JSON points, and the fund-type source-of-truth invariants from §1. Nothing covers `lib/js/fund-type-radio.js`; see §1.
 
 ### Why the tests stub WordPress rather than run inside it
 
@@ -122,7 +129,7 @@ The suite covers functions that are pure once WordPress is stubbed. Anything nee
 
 ## 5. Maintenance
 
-- **Dependabot alerts are all `development` scope.** Zero production-scope, and the shipped ZIP contains only `acf-json/`, `lib/`, `plugin.php` and docs — no `node_modules`. **Nothing here reaches a WordPress site.** The whole backlog is the `@wordpress/scripts` transitive tree, which exists solely to provide `plugin-zip`; the plugin ships no JavaScript and has no build step. Housekeeping, not a security matter — and worth remembering before a raw alert count is read as risk.
+- **Dependabot alerts are all `development` scope.** Zero production-scope, and the shipped ZIP contains only `acf-json/`, `lib/`, `plugin.php` and docs — no `node_modules`. **Nothing here reaches a WordPress site.** The whole backlog is the `@wordpress/scripts` transitive tree, which exists solely to provide `plugin-zip`; the one JavaScript file the plugin ships is hand-written and has no build step. Housekeeping, not a security matter — and worth remembering before a raw alert count is read as risk.
 
   [#137](https://github.com/ucsc/ucsc-giving-functionality/issues/137) bumped `@wordpress/scripts` 30 → 34 and applied the non-breaking fixes, taking `npm audit` from 63 to 29 and clearing every critical. What remains is held behind `semver-major` bumps inside that tree — `adm-zip`, `markdown-it`/`linkify-it`, `minimatch`, and `webpack-dev-server` via `sockjs` — so it cannot be cleared without either forcing breaking upgrades or waiting for upstream. Not worth forcing, given zero production exposure.
 
@@ -137,4 +144,5 @@ The suite covers functions that are pure once WordPress is stubbed. Anything nee
 - **Integration tests against a real WordPress install.** Deliberate, not an oversight — see §3. The fund URL path depends on an ACF Pro options page registered by the `ucsc-2022` theme, so automating it in CI would mean holding a commercial licence key as a repository secret. The unit suite covers the logic; the rest is hand-verified.
 - Rewriting the plugin as class-based / namespaced. The procedural structure is small and consistent; churn here would buy little.
 - Registering the post type and taxonomies in PHP. `acf-json/` is the working source of truth and the ACF admin round-trips to it.
-- Shipping a build step for front-end assets. The plugin ships no JavaScript, and `@wordpress/scripts` is used only for `plugin-zip`.
+- Shipping a build step for front-end assets. The plugin ships no front-end JavaScript at all, and its one admin script (`lib/js/fund-type-radio.js`, §1) is written against the `wp.*` globals precisely so it needs no bundler. `@wordpress/scripts` is used only for `plugin-zip`.
+- A JavaScript test suite. One hand-written admin file does not justify the toolchain; the invariant it expresses is covered in PHP by `SingleFundTypeTest`, which is the half that actually protects the data.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,6 +50,8 @@ A fund is Standard *or* Priority, never both. The ACF radio enforced that struct
 
 **Everywhere else**, `ucscgiving_enforce_single_fund_type()` on `set_object_terms` trims fund-type to one term. Quick Edit and Bulk Edit still render checkboxes, and REST clients, WP-CLI and imports never touch the admin at all. `set_object_terms` is the hook rather than `save_post` because `WP_REST_Posts_Controller::update_item()` runs `wp_update_post()` — and therefore `save_post` — *before* `handle_terms()` writes the terms; it would inspect the terms before they existed. This is a normaliser over the single store, not a third writer arbitrating between two.
 
+**A new fund starts as Priority.** The old ACF radio had `allow_null: 0` and preselected; a radio over a taxonomy shows nothing until a term exists, so the taxonomy carries a `default_term` of `Priority`. Priority is the safe half of the pair — a brand-new fund keeps its own page rather than pointing visitors at an external giving form before it has a designation code. Note that WordPress resolves this with `term_exists( name, taxonomy )` and creates a new term on a miss, so the name must keep matching the existing term exactly; `FundTypeSourceOfTruthTest` asserts it. A side effect worth knowing: core will not let a default term be deleted from the Fund Types screen.
+
 Also new to the admin, both by-products of `show_ui`: a **Fund Types** submenu for term management, and a fund-type control in Quick Edit.
 
 `tests/php/FundTypeSourceOfTruthTest.php` asserts that no ACF field in the Fund Details group targets the `fund-type` taxonomy, since `acf-json/` is round-tripped through the ACF admin and adding one back would reinstate the second writer silently.
@@ -81,7 +83,7 @@ The middle option also gives the existing settings page a reason to exist beyond
 **Largely done.** [#127](https://github.com/ucsc/ucsc-giving-functionality/pull/130) and [#128](https://github.com/ucsc/ucsc-giving-functionality/pull/131) landed on 2026-08-04. What exists now:
 
 - **PR checks.** `.github/workflows/ci.yml` runs `composer lint` and `composer test` on every pull request, across PHP 8.1 and 8.4. Previously `release.yml` only fired on tags, so nothing validated a PR at all.
-- **A PHPUnit suite** — 43 tests over `ucscgiving_link_filter()` (every branch), `ucscgiving_build_fund_url()`, `ucscgiving_fund_url()`, `ucscgiving_fund_search_template()`, `ucscgiving_create_fund_search_variation()`, `ucscgiving_enforce_single_fund_type()`, the two ACF JSON points, and the fund-type source-of-truth invariants from §1. Nothing covers `lib/js/fund-type-radio.js`; see §1.
+- **A PHPUnit suite** — 44 tests over `ucscgiving_link_filter()` (every branch), `ucscgiving_build_fund_url()`, `ucscgiving_fund_url()`, `ucscgiving_fund_search_template()`, `ucscgiving_create_fund_search_variation()`, `ucscgiving_enforce_single_fund_type()`, the two ACF JSON points, and the fund-type source-of-truth invariants from §1. Nothing covers `lib/js/fund-type-radio.js`; see §1.
 
 ### Why the tests stub WordPress rather than run inside it
 

--- a/acf-json/taxonomy_67cc736da6678.json
+++ b/acf-json/taxonomy_67cc736da6678.json
@@ -65,11 +65,14 @@
     "query_var": "post_type_key",
     "query_var_name": "",
     "default_term": {
-        "default_term_enabled": "0"
+        "default_term_enabled": "1",
+        "default_term_name": "Priority",
+        "default_term_slug": "",
+        "default_term_description": ""
     },
     "sort": 0,
     "meta_box": "default",
     "meta_box_cb": "",
     "meta_box_sanitize_cb": "",
-    "modified": 1786718878
+    "modified": 1786723638
 }

--- a/lib/functions/general.php
+++ b/lib/functions/general.php
@@ -110,6 +110,57 @@ function ucscgiving_link_filter( $post_link, $post ) {
 add_filter( 'post_type_link', 'ucscgiving_link_filter', 10, 2 );
 
 /**
+ * Keep a fund to a single fund type
+ *
+ * A fund is either Standard or Priority, never both. The block editor is held
+ * to that by lib/js/fund-type-radio.js, but quick edit and bulk edit still
+ * render checkboxes, and REST clients, WP-CLI and imports bypass the admin
+ * entirely. This enforces the invariant where none of them can get around it.
+ *
+ * This is a normaliser over the one store that owns fund type, not a third
+ * writer arbitrating between two of them — the arrangement #3 removed and
+ * PR #21 was closed for reproducing.
+ *
+ * `set_object_terms` is the hook rather than `save_post` because
+ * WP_REST_Posts_Controller::update_item() runs wp_update_post() — and so
+ * `save_post` — *before* handle_terms() writes the terms. This one fires from
+ * inside wp_set_object_terms() itself, so it sees every write path alike.
+ *
+ * That does mean the corrective write re-enters this function. No reentrancy
+ * flag is needed: the write always sets exactly one term, and both count
+ * guards below bail on one term, so the second pass stops there. Those guards
+ * are load-bearing, not just an early-out — weaken both and this recurses
+ * until PHP runs out of memory.
+ *
+ * @param int    $object_id Object ID.
+ * @param array  $terms     Term IDs or slugs that were set.
+ * @param array  $tt_ids    Term taxonomy IDs that were set.
+ * @param string $taxonomy  Taxonomy slug.
+ * @return void
+ */
+function ucscgiving_enforce_single_fund_type( $object_id, $terms, $tt_ids, $taxonomy ) {
+	if ( 'fund-type' !== $taxonomy || count( $tt_ids ) < 2 ) {
+		return;
+	}
+
+	$term_ids = wp_get_object_terms( $object_id, 'fund-type', array( 'fields' => 'ids' ) );
+
+	// A WP_Error is not an array, so this covers the failure case too.
+	if ( ! is_array( $term_ids ) || count( $term_ids ) < 2 ) {
+		return;
+	}
+
+	// Which term survives is arbitrary but must be deterministic. With the
+	// radio in place nothing should reach this; the point is only that a fund
+	// is never left in both states.
+	$keep = (int) end( $term_ids );
+
+	wp_set_object_terms( $object_id, array( $keep ), 'fund-type', false );
+}
+
+add_action( 'set_object_terms', 'ucscgiving_enforce_single_fund_type', 10, 4 );
+
+/**
  * Register Search block variation for Fund post type
  * description: Registers a custom block variation for the Fund post type
  *

--- a/lib/js/fund-type-radio.js
+++ b/lib/js/fund-type-radio.js
@@ -1,0 +1,117 @@
+/**
+ * Render the Fund Type taxonomy as radio buttons in the block editor.
+ *
+ * A fund is either Standard or Priority, never both. WordPress renders a
+ * hierarchical taxonomy as a checkbox list, which does not express that, so
+ * this swaps the control for a single-choice radio via the documented
+ * `editor.PostTaxonomyType` filter.
+ *
+ * The filter is the only supported way in: a taxonomy's `meta_box_cb` is
+ * registered with `__back_compat_meta_box => true` unconditionally by core, so
+ * the block editor discards it and a custom radio meta box would only ever
+ * appear in the classic editor.
+ *
+ * This is the editor affordance only. `ucscgiving_enforce_single_fund_type()`
+ * in lib/functions/general.php enforces the same invariant server-side, where
+ * quick edit, bulk edit, REST clients and WP-CLI cannot bypass it.
+ *
+ * Hand-written against the wp.* globals: the plugin has no build step, so
+ * there is no JSX and no ES module syntax here.
+ *
+ * @package ucsc-giving-functionality
+ */
+
+( function ( wp, config ) {
+	'use strict';
+
+	if ( ! wp || ! wp.hooks || ! wp.element || ! wp.data || ! wp.components || ! config ) {
+		return;
+	}
+
+	var el = wp.element.createElement;
+
+	// Every term, name-ordered. Only id and name are needed to draw the radios.
+	var TERM_QUERY = {
+		per_page: -1,
+		orderby: 'name',
+		order: 'asc',
+		_fields: 'id,name',
+		context: 'view',
+	};
+
+	/**
+	 * A single-choice control over the fund-type terms.
+	 *
+	 * Reads and writes the same editor entity state the default checkbox list
+	 * uses, so saving is unchanged — only the affordance differs.
+	 *
+	 * @return {Object|null} The radio control, or null while terms load.
+	 */
+	function FundTypeRadio() {
+		// rest_base is what the editor keys the post's terms under. It is
+		// empty in the taxonomy JSON, so WordPress derives it from the
+		// taxonomy name — read it rather than assuming either.
+		var taxonomy = wp.data.useSelect( function ( select ) {
+			return select( 'core' ).getTaxonomy( config.taxonomy );
+		}, [] );
+
+		var terms = wp.data.useSelect( function ( select ) {
+			return select( 'core' ).getEntityRecords( 'taxonomy', config.taxonomy, TERM_QUERY );
+		}, [] );
+
+		var selected = wp.data.useSelect(
+			function ( select ) {
+				if ( ! taxonomy ) {
+					return null;
+				}
+
+				return select( 'core/editor' ).getEditedPostAttribute( taxonomy.rest_base );
+			},
+			[ taxonomy ]
+		);
+
+		var editPost = wp.data.useDispatch( 'core/editor' ).editPost;
+
+		if ( ! taxonomy || ! terms ) {
+			return null;
+		}
+
+		var options = terms.map( function ( term ) {
+			return { label: term.name, value: String( term.id ) };
+		} );
+
+		return el( wp.components.RadioControl, {
+			__nextHasNoMarginBottom: true,
+			label: config.label,
+			selected: selected && selected.length ? String( selected[ 0 ] ) : null,
+			options: options,
+			onChange: function ( value ) {
+				var update = {};
+
+				// Always a one-element array. This is what makes the control
+				// single-choice as far as the save cycle is concerned.
+				update[ taxonomy.rest_base ] = [ parseInt( value, 10 ) ];
+
+				editPost( update );
+			},
+		} );
+	}
+
+	wp.hooks.addFilter(
+		'editor.PostTaxonomyType',
+		'ucscgiving/fund-type-radio',
+		function ( OriginalComponent ) {
+			return function ( props ) {
+				// Everything that is not fund-type keeps the default control.
+				// Note that OriginalComponent is passed through rather than
+				// HierarchicalTermSelector being called directly, which the
+				// Gutenberg docs warn locks the editor up.
+				if ( props.slug !== config.taxonomy ) {
+					return el( OriginalComponent, props );
+				}
+
+				return el( FundTypeRadio, props );
+			};
+		}
+	);
+} )( window.wp, window.ucscgivingFundType );

--- a/plugin.php
+++ b/plugin.php
@@ -62,6 +62,63 @@ if ( ! function_exists( 'ucscgiving_enqueue_admin_styles' ) ) {
 }
 add_action( 'admin_enqueue_scripts', 'ucscgiving_enqueue_admin_styles' );
 
+// Enqueue the block editor script that makes Fund Type a single choice.
+if ( ! function_exists( 'ucscgiving_enqueue_block_editor_assets' ) ) {
+	/**
+	 * Enqueue block editor assets for the Fund post type
+	 *
+	 * Loads the script that swaps the Fund Type checkbox list for radio
+	 * buttons. Only the fund editor needs it, so every other screen is left
+	 * alone.
+	 *
+	 * Both this and ucscgiving_enqueue_admin_styles() build their URL with
+	 * plugin_dir_url( __FILE__ ), which resolves to the plugin root only
+	 * because this file sits there. Moving either into lib/functions/ would
+	 * silently produce a broken URL.
+	 *
+	 * @since 0.5.9
+	 * @package ucsc-giving-functionality
+	 */
+	function ucscgiving_enqueue_block_editor_assets(): void {
+		$current_screen = get_current_screen();
+
+		// get_current_screen() returns null outside a real admin screen.
+		if ( ! $current_screen instanceof WP_Screen ) {
+			return;
+		}
+
+		if ( 'fund' !== $current_screen->post_type ) {
+			return;
+		}
+
+		$script         = plugin_dir_url( __FILE__ ) . 'lib/js/fund-type-radio.js';
+		$plugin_data    = get_plugin_data( UCSCGIVING_PLUGIN_DIR . 'plugin.php' );
+		$plugin_version = $plugin_data['Version'];
+
+		wp_register_script(
+			'ucscgiving-fund-type-radio',
+			$script,
+			array( 'wp-hooks', 'wp-element', 'wp-components', 'wp-data', 'wp-core-data' ),
+			$plugin_version,
+			true
+		);
+
+		// Translatable strings stay in PHP, where the ucscgiving text domain is
+		// already enforced, rather than needing script translations.
+		wp_localize_script(
+			'ucscgiving-fund-type-radio',
+			'ucscgivingFundType',
+			array(
+				'taxonomy' => 'fund-type',
+				'label'    => __( 'Fund Type', 'ucscgiving' ),
+			)
+		);
+
+		wp_enqueue_script( 'ucscgiving-fund-type-radio' );
+	}
+}
+add_action( 'enqueue_block_editor_assets', 'ucscgiving_enqueue_block_editor_assets' );
+
 /**
  * ACF JSON Save Point
  *

--- a/tests/doubles/class-ucscgiving-test-state.php
+++ b/tests/doubles/class-ucscgiving-test-state.php
@@ -28,11 +28,25 @@ final class UCSCGiving_Test_State {
 	public static $meta = array();
 
 	/**
-	 * Term names assigned to a post, keyed by "{post_id}:{taxonomy}".
+	 * Terms assigned to a post, keyed by "{post_id}:{taxonomy}".
+	 *
+	 * Each entry maps term ID to term name, so one bucket serves both the name
+	 * lookup has_term() does and the ID list wp_get_object_terms() returns.
 	 *
 	 * @var array<string,array<int,string>>
 	 */
 	public static $object_terms = array();
+
+	/**
+	 * Calls made to wp_set_object_terms(), oldest first.
+	 *
+	 * Each entry is array( $object_id, $terms, $taxonomy, $append ). Lets a
+	 * test assert not just the resulting state but whether a write happened
+	 * at all.
+	 *
+	 * @var array<int,array<int,mixed>>
+	 */
+	public static $term_writes = array();
 
 	/**
 	 * Value returned by is_search().
@@ -71,6 +85,7 @@ final class UCSCGiving_Test_State {
 		self::$fields           = array();
 		self::$meta             = array();
 		self::$object_terms     = array();
+		self::$term_writes      = array();
 		self::$is_search        = false;
 		self::$query_vars       = array();
 		self::$located_template = '';

--- a/tests/php/BuildFundUrlTest.php
+++ b/tests/php/BuildFundUrlTest.php
@@ -101,7 +101,7 @@ class BuildFundUrlTest extends TestCase {
 	 */
 	public function test_binding_and_permalink_agree_for_a_standard_fund() {
 		UCSCGiving_Test_State::$fields['base_url']          = 'https://give.example.edu/fund/';
-		UCSCGiving_Test_State::$object_terms['7:fund-type'] = array( 'Standard' );
+		UCSCGiving_Test_State::$object_terms['7:fund-type'] = array( 99 => 'Standard' );
 		UCSCGiving_Test_State::$meta['7:designation']       = 'ABC123';
 		UCSCGiving_Test_State::$current_post_id             = 7;
 

--- a/tests/php/FundTypeSourceOfTruthTest.php
+++ b/tests/php/FundTypeSourceOfTruthTest.php
@@ -86,6 +86,29 @@ class FundTypeSourceOfTruthTest extends TestCase {
 	}
 
 	/**
+	 * A new fund starts as Priority.
+	 *
+	 * The old ACF radio had `allow_null: 0` and preselected a value; a radio
+	 * over the taxonomy shows nothing selected until a term exists. The
+	 * taxonomy's own default term restores that, and Priority is the safe
+	 * default of the two — it keeps the fund on its own page rather than
+	 * sending visitors to an external giving form for a fund that has no
+	 * designation code yet.
+	 *
+	 * The name has to match the existing term exactly. WordPress resolves the
+	 * default with term_exists( name, taxonomy ) and creates a **new** term
+	 * when it misses, so a typo here silently produces a duplicate.
+	 *
+	 * @return void
+	 */
+	public function test_a_new_fund_defaults_to_priority() {
+		$taxonomy = $this->fund_type_taxonomy();
+
+		$this->assertSame( '1', $taxonomy['default_term']['default_term_enabled'] );
+		$this->assertSame( 'Priority', $taxonomy['default_term']['default_term_name'] );
+	}
+
+	/**
 	 * The front end still needs the taxonomy public and queryable.
 	 *
 	 * `taxonomy-fund-type.php` is a registered block template and /fund-type/

--- a/tests/php/LinkFilterTest.php
+++ b/tests/php/LinkFilterTest.php
@@ -55,7 +55,7 @@ class LinkFilterTest extends TestCase {
 	 * @return object
 	 */
 	private function make_fund( $post_id = 7, $term_name = 'Standard' ) {
-		UCSCGiving_Test_State::$object_terms[ $post_id . ':fund-type' ] = array( $term_name );
+		UCSCGiving_Test_State::$object_terms[ $post_id . ':fund-type' ] = array( 99 => $term_name );
 
 		return $this->make_post( $post_id, 'fund' );
 	}
@@ -93,7 +93,7 @@ class LinkFilterTest extends TestCase {
 	public function test_returns_permalink_when_the_term_belongs_to_another_post() {
 		UCSCGiving_Test_State::$fields['base_url']          = 'https://give.example.edu/fund/';
 		UCSCGiving_Test_State::$meta['7:designation']       = 'ABC123';
-		UCSCGiving_Test_State::$object_terms['8:fund-type'] = array( 'Standard' );
+		UCSCGiving_Test_State::$object_terms['8:fund-type'] = array( 99 => 'Standard' );
 
 		$post = $this->make_post( 7, 'fund' );
 
@@ -108,7 +108,7 @@ class LinkFilterTest extends TestCase {
 	public function test_returns_permalink_when_standard_is_in_another_taxonomy() {
 		UCSCGiving_Test_State::$fields['base_url']     = 'https://give.example.edu/fund/';
 		UCSCGiving_Test_State::$meta['7:designation']  = 'ABC123';
-		UCSCGiving_Test_State::$object_terms['7:area'] = array( 'Standard' );
+		UCSCGiving_Test_State::$object_terms['7:area'] = array( 42 => 'Standard' );
 
 		$post = $this->make_post( 7, 'fund' );
 
@@ -116,20 +116,22 @@ class LinkFilterTest extends TestCase {
 	}
 
 	/**
-	 * Documents the risk the taxonomy panel introduces.
+	 * Defence in depth: a multi-term fund still resolves to one destination.
 	 *
-	 * The ACF radio this replaced could hold one value. WordPress renders a
-	 * hierarchical taxonomy as a checkbox list, so an editor can now tick
-	 * Standard *and* Priority, and the fund links out. Nothing in the data
-	 * model prevents it; this pins what happens when it occurs rather than
-	 * claiming it is desirable.
+	 * A fund should never carry two fund types — the editor offers a radio and
+	 * ucscgiving_enforce_single_fund_type() normalises anything that gets past
+	 * it. Should one reach the read path anyway, the permalink must still be
+	 * decided rather than left ambiguous. This pins which way it goes.
 	 *
 	 * @return void
 	 */
 	public function test_links_out_when_standard_is_one_of_several_terms() {
 		UCSCGiving_Test_State::$fields['base_url']          = 'https://give.example.edu/fund/';
 		UCSCGiving_Test_State::$meta['7:designation']       = 'ABC123';
-		UCSCGiving_Test_State::$object_terms['7:fund-type'] = array( 'Priority', 'Standard' );
+		UCSCGiving_Test_State::$object_terms['7:fund-type'] = array(
+			98 => 'Priority',
+			99 => 'Standard',
+		);
 
 		$post = $this->make_post( 7, 'fund' );
 

--- a/tests/php/SingleFundTypeTest.php
+++ b/tests/php/SingleFundTypeTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Tests for ucscgiving_enforce_single_fund_type().
+ *
+ * @package ucsc-giving-functionality
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the invariant that a fund carries at most one fund-type term.
+ *
+ * The block editor is held to this by lib/js/fund-type-radio.js, which has no
+ * test harness. These cover the server-side normaliser, which is what quick
+ * edit, bulk edit, REST clients and WP-CLI actually hit.
+ */
+class SingleFundTypeTest extends TestCase {
+
+	/**
+	 * Reset the WordPress stubs before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		UCSCGiving_Test_State::reset();
+	}
+
+	/**
+	 * Assign fund-type terms to a post, bypassing the stubbed writer.
+	 *
+	 * @param array $terms Term ID to term name.
+	 * @param int   $post_id Post ID.
+	 * @return void
+	 */
+	private function assign_fund_types( $terms, $post_id = 7 ) {
+		UCSCGiving_Test_State::$object_terms[ $post_id . ':fund-type' ] = $terms;
+	}
+
+	/**
+	 * Two fund types collapse to one.
+	 *
+	 * @return void
+	 */
+	public function test_trims_two_fund_types_to_one() {
+		$this->assign_fund_types(
+			array(
+				98 => 'Priority',
+				99 => 'Standard',
+			)
+		);
+
+		ucscgiving_enforce_single_fund_type( 7, array( 98, 99 ), array( 98, 99 ), 'fund-type' );
+
+		$this->assertSame(
+			array( 99 ),
+			array_keys( UCSCGiving_Test_State::$object_terms['7:fund-type'] )
+		);
+	}
+
+	/**
+	 * The surviving term is the last one, deterministically.
+	 *
+	 * Which term wins is arbitrary; that it is always the same one is not.
+	 *
+	 * @return void
+	 */
+	public function test_keeps_the_last_term_and_writes_once() {
+		$this->assign_fund_types(
+			array(
+				98 => 'Priority',
+				99 => 'Standard',
+			)
+		);
+
+		ucscgiving_enforce_single_fund_type( 7, array( 98, 99 ), array( 98, 99 ), 'fund-type' );
+
+		$this->assertCount( 1, UCSCGiving_Test_State::$term_writes );
+		$this->assertSame(
+			array( 7, array( 99 ), 'fund-type', false ),
+			UCSCGiving_Test_State::$term_writes[0]
+		);
+	}
+
+	/**
+	 * The corrective write must settle rather than cascade.
+	 *
+	 * The write re-enters the normaliser, because the stubbed
+	 * wp_set_object_terms() fires the hook the way core does. It terminates
+	 * because that write sets exactly one term, which both count guards bail
+	 * on. Weaken both and this recurses until PHP exhausts memory — which is
+	 * why this asserts the write count rather than just the end state.
+	 *
+	 * @return void
+	 */
+	public function test_does_not_recurse_on_its_own_write() {
+		$this->assign_fund_types(
+			array(
+				97 => 'Priority',
+				98 => 'Standard',
+				99 => 'Legacy',
+			)
+		);
+
+		ucscgiving_enforce_single_fund_type( 7, array( 97, 98, 99 ), array( 97, 98, 99 ), 'fund-type' );
+
+		$this->assertCount( 1, UCSCGiving_Test_State::$term_writes );
+	}
+
+	/**
+	 * A single fund type is left completely alone.
+	 *
+	 * The common path must not write to the database at all.
+	 *
+	 * @return void
+	 */
+	public function test_leaves_a_single_fund_type_untouched() {
+		$this->assign_fund_types( array( 99 => 'Standard' ) );
+
+		ucscgiving_enforce_single_fund_type( 7, array( 99 ), array( 99 ), 'fund-type' );
+
+		$this->assertSame( array(), UCSCGiving_Test_State::$term_writes );
+		$this->assertSame(
+			array( 99 => 'Standard' ),
+			UCSCGiving_Test_State::$object_terms['7:fund-type']
+		);
+	}
+
+	/**
+	 * Removing every fund type is not corrected into one.
+	 *
+	 * @return void
+	 */
+	public function test_leaves_a_fund_with_no_type_untouched() {
+		ucscgiving_enforce_single_fund_type( 7, array(), array(), 'fund-type' );
+
+		$this->assertSame( array(), UCSCGiving_Test_State::$term_writes );
+	}
+
+	/**
+	 * Other taxonomies are none of its business.
+	 *
+	 * Areas and Keywords are legitimately multi-term.
+	 *
+	 * @return void
+	 */
+	public function test_ignores_other_taxonomies() {
+		UCSCGiving_Test_State::$object_terms['7:area'] = array(
+			10 => 'Arts',
+			11 => 'Engineering',
+		);
+
+		ucscgiving_enforce_single_fund_type( 7, array( 10, 11 ), array( 10, 11 ), 'area' );
+
+		$this->assertSame( array(), UCSCGiving_Test_State::$term_writes );
+		$this->assertCount( 2, UCSCGiving_Test_State::$object_terms['7:area'] );
+	}
+
+	/**
+	 * The normaliser works off the post it is handed, not another one.
+	 *
+	 * @return void
+	 */
+	public function test_normalises_only_the_given_post() {
+		$this->assign_fund_types(
+			array(
+				98 => 'Priority',
+				99 => 'Standard',
+			),
+			7
+		);
+		$this->assign_fund_types(
+			array(
+				98 => 'Priority',
+				99 => 'Standard',
+			),
+			8
+		);
+
+		ucscgiving_enforce_single_fund_type( 7, array( 98, 99 ), array( 98, 99 ), 'fund-type' );
+
+		$this->assertCount( 1, UCSCGiving_Test_State::$object_terms['7:fund-type'] );
+		$this->assertCount( 2, UCSCGiving_Test_State::$object_terms['8:fund-type'] );
+	}
+}

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -165,20 +165,92 @@ if ( ! function_exists( 'has_term' ) ) {
 	/**
 	 * Object-term lookup stand-in.
 	 *
-	 * Matches on term name, which is all the plugin asks for. Real has_term()
-	 * also accepts a slug or a term ID, and takes a post object as well as an
-	 * ID; both are handled here so the stub cannot pass for the wrong reason.
+	 * Matches a term name against the values and a term ID against the keys,
+	 * mirroring core's name-or-slug-or-ID behaviour. Takes a post object as
+	 * well as an ID, so the stub cannot pass for the wrong reason.
 	 *
-	 * @param string          $term     Term name.
+	 * @param string|int      $term     Term name or term ID.
 	 * @param string          $taxonomy Taxonomy name.
 	 * @param int|object|null $post     Post ID or post object.
 	 * @return bool
 	 */
 	function has_term( $term = '', $taxonomy = '', $post = null ) {
-		$post_id = is_object( $post ) ? $post->ID : (int) $post;
-		$names   = UCSCGiving_Test_State::$object_terms[ $post_id . ':' . $taxonomy ] ?? array();
+		$post_id  = is_object( $post ) ? $post->ID : (int) $post;
+		$assigned = UCSCGiving_Test_State::$object_terms[ $post_id . ':' . $taxonomy ] ?? array();
 
-		return in_array( $term, $names, true );
+		if ( is_int( $term ) ) {
+			return array_key_exists( $term, $assigned );
+		}
+
+		return in_array( $term, array_values( $assigned ), true );
+	}
+}
+
+if ( ! function_exists( 'wp_get_object_terms' ) ) {
+	/**
+	 * Object-term list stand-in.
+	 *
+	 * Only the 'ids' field is modelled, which is all the plugin asks for.
+	 *
+	 * @param int    $object_id Object ID.
+	 * @param string $taxonomy  Taxonomy name.
+	 * @param array  $args      Query arguments.
+	 * @return array
+	 */
+	function wp_get_object_terms( $object_id, $taxonomy, $args = array() ) {
+		$assigned = UCSCGiving_Test_State::$object_terms[ $object_id . ':' . $taxonomy ] ?? array();
+
+		if ( isset( $args['fields'] ) && 'ids' === $args['fields'] ) {
+			return array_keys( $assigned );
+		}
+
+		return $assigned;
+	}
+}
+
+if ( ! function_exists( 'wp_set_object_terms' ) ) {
+	/**
+	 * Object-term write stand-in.
+	 *
+	 * Records the call and applies it to the assigned terms, so a caller that
+	 * writes and then re-reads sees its own write.
+	 *
+	 * It also fires the one hook core fires from here. add_action() is a no-op
+	 * in this harness, so without this the plugin's set_object_terms callback
+	 * would never re-enter and nothing would test that its corrective write
+	 * settles instead of cascading.
+	 *
+	 * Term names are not recoverable from IDs alone, so the previous name is
+	 * carried over where it is known and an empty string used otherwise.
+	 *
+	 * @param int    $object_id Object ID.
+	 * @param array  $terms     Term IDs to set.
+	 * @param string $taxonomy  Taxonomy name.
+	 * @param bool   $append    Whether to append rather than replace.
+	 * @return array The term IDs now assigned.
+	 */
+	function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
+		UCSCGiving_Test_State::$term_writes[] = array( $object_id, $terms, $taxonomy, $append );
+
+		$key      = $object_id . ':' . $taxonomy;
+		$existing = UCSCGiving_Test_State::$object_terms[ $key ] ?? array();
+		$updated  = $append ? $existing : array();
+
+		foreach ( (array) $terms as $term_id ) {
+			$updated[ (int) $term_id ] = $existing[ (int) $term_id ] ?? '';
+		}
+
+		UCSCGiving_Test_State::$object_terms[ $key ] = $updated;
+
+		$tt_ids = array_keys( $updated );
+
+		// Stands in for do_action( 'set_object_terms', … ) at the end of core's
+		// wp_set_object_terms().
+		if ( function_exists( 'ucscgiving_enforce_single_fund_type' ) ) {
+			ucscgiving_enforce_single_fund_type( $object_id, $terms, $tt_ids, $taxonomy );
+		}
+
+		return $tt_ids;
 	}
 }
 


### PR DESCRIPTION
Stacked on #3's data-model change. **Base is `fix/3-fund-type-taxonomy-source-of-truth`, not `main`** — merge that one first, after which GitHub retargets this PR to `main` automatically.

## Why

Making the taxonomy the single source of truth fixed the double-save, but it cost the thing the ACF radio gave for free: a fund is Standard **or** Priority, never both. WordPress renders a hierarchical taxonomy as a checkbox list, which does not express that.

## What

**In the editor** — `lib/js/fund-type-radio.js` swaps the checkbox list for a `RadioControl` through the `editor.PostTaxonomyType` filter. That filter is the only supported route: core registers taxonomy meta boxes with `__back_compat_meta_box => true` *unconditionally*, so a custom `meta_box_cb` is discarded by the block editor and would only ever appear in the classic editor.

This is the plugin's first browser JavaScript. Hand-written against the `wp.*` globals — no build step, no bundler — and its strings are passed in from PHP via `wp_localize_script()` so the text domain stays where PHPCS enforces it. Enqueued from `plugin.php` rather than `lib/functions/`, because `plugin_dir_url( __FILE__ )` only resolves to the plugin root from there.

**Everywhere else** — `ucscgiving_enforce_single_fund_type()` on `set_object_terms` trims fund-type to one term. Quick Edit and Bulk Edit still render checkboxes, and REST clients, WP-CLI and imports never touch the admin at all.

`set_object_terms` rather than `save_post`: `WP_REST_Posts_Controller::update_item()` runs `wp_update_post()` — and therefore `save_post` — *before* `handle_terms()` writes the terms, so a `save_post` guard would inspect terms that do not exist yet. This is a normaliser over the one store that owns fund type, not a third writer arbitrating between two, which is the arrangement #3 removed and PR #21 was closed for reproducing.

**A new fund defaults to Priority** — the ACF radio had `allow_null: 0` and preselected; a radio over a taxonomy shows nothing until a term exists. Priority is the safe half of the pair: a new fund keeps its own page rather than pointing visitors at an external giving form before it has a designation code.

## Notes for review

- **No reentrancy flag.** The corrective write re-enters the callback, but both count guards bail on one term. Verified by mutation: weakening either still terminates, weakening both recurses until PHP exhausts memory. A `static` flag would have been dead code no test could reach.
- **The `wp_set_object_terms()` stub now fires the hook core fires.** `add_action()` is a no-op in this harness, so without it the recursion path was never exercised and the test would have passed against any implementation.
- **The default term's name must keep matching the existing term.** WordPress resolves it with `term_exists( name, taxonomy )` and creates a *new* term on a miss, so a rename without a matching `acf-json/` edit produces a duplicate rather than an error. `FundTypeSourceOfTruthTest` asserts the name.

## Verification

44 tests passing, `composer lint` clean, and `npm run zip` confirms `lib/js/fund-type-radio.js` ships.

Not covered by anything automated — there is no JS test harness and none is proposed:

- [ ] Fund Type renders as radio buttons; picking one deselects the other
- [ ] A type change sticks on a **single** save
- [ ] A brand-new Fund opens with Priority preselected
- [ ] Quick Edit with both ticked leaves exactly one after save
- [ ] Other taxonomy panels (Areas, Keywords) still render normally — the `OriginalComponent` fall-through
- [ ] No console errors and no 404 on the script

Refs #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)